### PR TITLE
Ability to expand all categories on service

### DIFF
--- a/app/assets/javascripts/admin/categories_form.js
+++ b/app/assets/javascripts/admin/categories_form.js
@@ -21,6 +21,22 @@ var main = (function () {
       curr = checkboxes[l];
       $(curr).click(_linkClickedHandler)
     }
+
+    // Set event handler for expand/collapse all buttons
+    $("#expand-categories-toggle").on("click", (e) => {
+      _toggleExpanded(e)
+    })
+
+    // Make sure all parent checkboxes of the checked box are checked
+    $(".checkbox").on("click", (e) => {
+      var el = $(e.target)
+
+      if (el.prop("checked") == true) {
+        _checkParentStates(el)
+      } else if (el.prop("checked") == false) {
+        _uncheckChildStates(el)
+      }
+    })
   }
 
   function _linkClickedHandler(evt)
@@ -49,19 +65,57 @@ var main = (function () {
     for (var l=0; l < lnks.length; l++)
     {
       curr = lnks[l];
-      if (checkbox.checked)
-      {
-        $(curr).removeClass('hide');
-      }
-      else
-      {
-        $(curr).addClass('hide');
-        checkbox = $('input',$(curr))
-        checkbox.prop('checked', false);
-        _checkState(prefix,depth,checkbox)
+
+      // Skips existing checkbox functionality if the categories are expanded
+      if (!$("#categories").hasClass("expanded")) {
+        if (checkbox.checked)
+        {
+          $(curr).removeClass('hide');
+        }
+        else
+        {
+          $(curr).addClass('hide');
+          checkbox = $('input',$(curr))
+          checkbox.prop('checked', false);
+          _checkState(prefix,depth,checkbox)
+        }
       }
     }
+  }
 
+  // Runs through all parents of a box that has been checked to make sure they are checked
+  function _checkParentStates(el) {
+    var parentCheckbox = el.parent().parents(".checkbox")
+    parentCheckbox.children("input").prop("checked", true)
+
+    if (el.parent().hasClass("depth0") || parentCheckbox.hasClass("depth0")) {
+      return
+    } else {
+      _checkParentStates(parentCheckbox.children("input"))
+    }
+  }
+
+  // Runs through all children checkboxes of a box that was unchecked to make sure they get unchecked
+  function _uncheckChildStates(el) {
+    el.prop("checked", false)
+    var childrenCheckboxes = el.parent(".checkbox").children().find(".checkbox input").prop("checked", false)
+  }
+
+  // Toggles categories between being expanded and collapsed. Changes checkbox collapsing behavior depending on state
+  function _toggleExpanded(e) {
+    $("#categories").toggleClass("expanded")
+
+    if ($("#categories").hasClass("expanded")) {
+      $(e.target).text("Collapse All")
+      $(".checkbox").removeClass("hide")
+    } else {
+      $(e.target).text("Expand All")
+      $(".checkbox").not(".depth0").not((i, el) => {
+        var checkbox_input = $(el).children("input")
+        var sibling_checkboxes = $(el).parent().parent().children("ul li input")
+        return checkbox_input.prop("checked") || sibling_checkboxes.prop("checked")
+      }).addClass("hide")
+    }
   }
 
   // return internally scoped var as value of globally scoped object

--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -281,3 +281,14 @@ a.boxed-action:active {
     margin: 0 10px;
   }
 }
+
+#expand-categories-toggle {
+  display: inline;
+  cursor: pointer;
+  text-decoration: underline;
+  color: #337ab7;
+
+  &:hover {
+    color: #2e6da4
+  }
+}

--- a/app/helpers/admin/form_helper.rb
+++ b/app/helpers/admin/form_helper.rb
@@ -35,6 +35,12 @@ class Admin
       end)
     end
 
+    def categories_expand_button
+      content_tag(:div, id: 'expand-categories-toggle') do
+        'Expand All'
+      end
+    end
+
     def cats_and_subcats(categories)
       cats = []
       categories.each do |array|

--- a/app/views/admin/services/forms/_categories.html.haml
+++ b/app/views/admin/services/forms/_categories.html.haml
@@ -8,6 +8,7 @@
   = hidden_field_tag 'service[category_ids][]', nil
   = field_set_tag nil, id: 'categories' do
     = f.label :services
+    = categories_expand_button
     = nested_categories(Category.services.arrange(order: :taxonomy_id))
     = f.label :situations
     = nested_categories(Category.situations.arrange(order: :taxonomy_id))


### PR DESCRIPTION
## Summary
Adds expand/collapse button to service categories on services form

**Zube Card Referenced** 49
https://zube.io/smartlogic/bchd/c/49

**Files Modified**
- `app/assets/javascripts/admin/categories_form.js`: Added functions for handling css classes and checkbox behavior for expanded/collapsed categories
- `app/assets/stylesheets/admin/application.css.scss`: Added styling for expand all button
- `app/helpers/admin/form_helper.rb`: Added categories expand/collapse view helper button definition
- `app/views/admin/services/forms/_categories.html.haml`: Added expand/collapse view helper button to categories form

### Migrations to Run: No