### PR TITLE
Add featured_at column to locations

### DIFF
--- a/app/chewy/locations_index.rb
+++ b/app/chewy/locations_index.rb
@@ -14,5 +14,6 @@ class LocationsIndex < Chewy::Index
     field :category_ids, value: -> { services.map(&:categories).flatten.uniq.map(&:id) }
     field :tags, value: -> { tags.map(&:name) }
     field :featured_at, type: 'date'
+    field :covid19, value: -> { covid19? ? created_at : nil }, type: 'date'
   end
 end

--- a/app/chewy/locations_index.rb
+++ b/app/chewy/locations_index.rb
@@ -13,5 +13,6 @@ class LocationsIndex < Chewy::Index
     field :keywords, value: -> { services.map(&:keywords).compact.join(', ') }
     field :category_ids, value: -> { services.map(&:categories).flatten.uniq.map(&:id) }
     field :tags, value: -> { tags.map(&:name) }
+    field :featured_at, type: 'date'
   end
 end

--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -74,7 +74,7 @@ class Admin
     def location_params
       params.require(:location).permit(
         :organization_id, { accessibility: [] }, :active, { admin_emails: [] },
-        :alternate_name, :description, :email, { languages: [] }, :latitude,
+        :alternate_name, :description, :email, :featured, { languages: [] }, :latitude,
         { tag_list: [] }, :longitude, :name, :short_desc, :transportation, :website, :virtual,
         address_attributes: %i[
           address_1 address_2 city state_province postal_code country id _destroy

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -22,14 +22,6 @@ module Api
 
         locations = locations.compact
 
-        # TODO: figure out a better place for this
-        if locations.any?(&:covid19?)
-          covid_19_locations = locations.select(&:covid19?).sort_by(&:updated_at).reverse
-          the_rest = locations.reject(&:covid19?)
-          the_rest.each { |loc| covid_19_locations << loc }
-          locations = covid_19_locations
-        end
-
         render json: locations, each_serializer: LocationsSerializer, status: :ok
       end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -31,6 +31,8 @@ class Location < ApplicationRecord
 
   update_index('locations#location') { self }
 
+  attr_accessor :featured
+
   belongs_to :organization, touch: true, optional: false
 
   has_one :address, dependent: :destroy
@@ -157,6 +159,15 @@ class Location < ApplicationRecord
 
   def full_address
     address.try(:full_address)
+  end
+
+  def featured
+    !featured_at.nil?
+  end
+
+  def featured=(value)
+    self.featured_at = nil
+    self.featured_at = Time.current if value == "1"
   end
 
   # See app/models/concerns/search.rb

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -35,7 +35,11 @@ class LocationsSearch
   end
 
   def order
-    index.order(:featured_at, :covid19)
+    index.order(
+      featured_at: { missing: "_last", order: "asc" },
+      covid19: { missing: "_last", order: "asc" },
+      updated_at: { order: "desc" }
+    )
   end
 
   def tags_query

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -35,7 +35,7 @@ class LocationsSearch
   end
 
   def order
-    index.order(:featured_at)
+    index.order(:featured_at, :covid19)
   end
 
   def tags_query

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -29,8 +29,13 @@ class LocationsSearch
       tags_query,
       keyword_filter,
       zipcode_filter,
-      category_filter
+      category_filter,
+      order
     ].compact.reduce(:merge)
+  end
+
+  def order
+    index.order(:featured_at)
   end
 
   def tags_query

--- a/app/serializers/locations_serializer.rb
+++ b/app/serializers/locations_serializer.rb
@@ -1,7 +1,7 @@
 class LocationsSerializer < ActiveModel::Serializer
   attributes :id, :active, :admin_emails, :alternate_name, :coordinates,
              :description, :latitude, :longitude, :name, :short_desc, :slug,
-             :website, :updated_at, :url
+             :website, :updated_at, :url, :featured
 
   has_one :address
   has_one :organization, serializer: LocationsOrganizationSerializer

--- a/app/views/admin/locations/forms/_featured.html.haml
+++ b/app/views/admin/locations/forms/_featured.html.haml
@@ -1,0 +1,9 @@
+.inst-box
+  %header
+    = f.label :featured
+  = field_set_tag do
+    .row
+      .col-sm-1
+        = f.check_box :featured, class: 'form-control'
+      .col-sm-1
+      Featured?

--- a/app/views/admin/locations/forms/_featured.html.haml
+++ b/app/views/admin/locations/forms/_featured.html.haml
@@ -2,8 +2,6 @@
   %header
     = f.label :featured
   = field_set_tag do
-    .row
-      .col-sm-1
-        = f.check_box :featured, class: 'form-control'
-      .col-sm-1
-      Featured?
+    .form-check
+      = f.check_box :featured, class: "form-check-input"
+      = f.label "Featured location?", class: "form-check-label"

--- a/app/views/admin/locations/forms/_fields.html.haml
+++ b/app/views/admin/locations/forms/_fields.html.haml
@@ -6,6 +6,7 @@
         %li= msg
 = render 'admin/shared/forms/choose_org', f: f, organization: location.organization
 = render 'admin/shared/forms/name', f: f
+= render 'admin/locations/forms/featured', f: f
 = render 'admin/shared/forms/alternate_name', f: f
 - if f.object.new_record? || policy(location).edit?
   = render 'admin/locations/forms/admin_emails', f: f, location: location

--- a/db/migrate/20200610142735_add_featured_at_column_to_location.rb
+++ b/db/migrate/20200610142735_add_featured_at_column_to_location.rb
@@ -1,0 +1,5 @@
+class AddFeaturedAtColumnToLocation < ActiveRecord::Migration[5.1]
+  def change
+    add_column :locations, :featured_at, :timestamp
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: fill_search_vector_for_location(); Type: FUNCTION; Schema: public; Owner: -
 --
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,20 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
 -- Name: fill_search_vector_for_location(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -391,7 +405,8 @@ CREATE TABLE public.locations (
     virtual boolean DEFAULT false,
     active boolean DEFAULT true,
     website character varying(255),
-    email character varying(255)
+    email character varying(255),
+    featured_at timestamp without time zone
 );
 
 
@@ -1507,6 +1522,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200410005234'),
 ('20200504145258'),
 ('20200504145923'),
-('20200511152900');
+('20200511152900'),
+('20200610142735');
 
 

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -546,7 +546,7 @@ describe "GET 'search'" do
   end
 
   context 'it should order the locations' do
-    before(:all) do
+    before(:each) do
       @organization = create(:organization)
 
       @loc1 = create_location("covid location", @organization)
@@ -556,7 +556,7 @@ describe "GET 'search'" do
       LocationsIndex.reset!
     end
 
-    after(:all) do
+    after(:each) do
       Organization.find_each(&:destroy)
     end
 
@@ -565,7 +565,11 @@ describe "GET 'search'" do
       expect(@loc2.organization.name).to eq('Parent Agency')
       expect(@loc3.organization.name).to eq('Parent Agency')
 
+      LocationsIndex.reset!
+
       get api_search_index_url(keyword: 'parent')
+
+      sleep 0.5
 
       expect(json[0]['name']).to eq(@loc3.name)
       expect(json[1]['name']).to eq(@loc1.name)
@@ -582,6 +586,8 @@ describe "GET 'search'" do
       LocationsIndex.reset!
 
       get api_search_index_url(keyword: 'parent')
+
+      sleep 0.5
 
       expect(json[0]['name']).to eq(@loc3.name)
       expect(json[1]['name']).to eq(@loc2.name)

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -5,8 +5,8 @@ describe "GET 'search'" do
     before :all do
       @loc = create(:location)
       @nearby = create(:nearby_loc)
-      @loc.update(updated_at: Time.zone.now - 1.day)
-      @nearby.update(updated_at: Time.zone.now - 1.hour)
+      @loc.update_columns(updated_at: Time.zone.now - 1.day)
+      @nearby.update_columns(updated_at: Time.zone.now - 1.hour)
       LocationsIndex.reset!
     end
 
@@ -570,6 +570,22 @@ describe "GET 'search'" do
       expect(json[0]['name']).to eq(@loc3.name)
       expect(json[1]['name']).to eq(@loc1.name)
       expect(json[2]['name']).to eq(@loc2.name)
+    end
+
+    it 'it should return locations order based on updated_at property if no featured_at and covid19 locations' do
+      time = Time.current
+
+      @loc1.update_columns(name: "regular location1", updated_at: time - 5.minutes)
+      @loc2.update_columns(name: "regular location2", updated_at: time - 3.minutes)
+      @loc3.update_columns(name: "regular location3", featured_at: time, updated_at: time - 1.minutes)
+
+      LocationsIndex.reset!
+
+      get api_search_index_url(keyword: 'parent')
+
+      expect(json[0]['name']).to eq(@loc3.name)
+      expect(json[1]['name']).to eq(@loc2.name)
+      expect(json[2]['name']).to eq(@loc1.name)
     end
   end
 end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     latitude { 37.583939 }
     longitude { -122.3715745 }
     organization
+    featured_at { nil }
     address
     # id {  SecureRandom.random_number(10) }
 

--- a/spec/features/admin/locations/create_location_spec.rb
+++ b/spec/features/admin/locations/create_location_spec.rb
@@ -13,7 +13,8 @@ feature 'Create a new location' do
 
     expect(current_path).to eq '/admin/locations/new-parent-agency-location'
     expect(find_field('location_name').value).to eq 'New Parent Agency location'
-    expect(find_field('location_description').value).to eq 'new description'
+    fill_in_editor_field 'new description'
+    expect(page).to have_editor_display text: 'new description'
     expect(find_field('location_address_attributes_address_1').value).
       to eq '123 Main St.'
     expect(find_field('location_address_attributes_city').value).
@@ -152,7 +153,8 @@ feature 'Create a new location' do
   scenario 'when setting the virtual attribute', :js do
     select2('Parent Agency', 'org-name')
     fill_in 'location_name', with: 'New Parent Agency location'
-    fill_in 'location_description', with: 'new description'
+    fill_in_editor_field 'new description'
+    expect(page).to have_editor_display text: 'new description'
     select('Does not have a physical address', from: 'location_virtual')
     click_button I18n.t('admin.buttons.create_location')
 

--- a/spec/support/features/form_helpers.rb
+++ b/spec/support/features/form_helpers.rb
@@ -56,19 +56,45 @@ module Features
     def delete_all_admins
       find_link(I18n.t('admin.buttons.delete_admin'), match: :first).click
       find_link(I18n.t('admin.buttons.delete_admin'), match: :first).click
+
+
+      # NOTE: 
+      # Currently, we are getting this following Selenium error:
+      #`````````````````````````````````````````````````````````1
+      # Selenium::WebDriver::Error::ElementClickInterceptedError:
+      # element click intercepted: Element <input type="submit" name="commit" value="Save changes &amp; apply edits to database" class="btn btn-success" data-disable-with="Please wait..."> 
+      # is not clickable at point (545, 563). Other element would receive the click: <div class="CodeMirror-scroll" tabindex="-1">...</div>
+      #``````````````````````````````````````````````````````````
+      # So added this hack temporarily but need a better way to fix this.
+      page.execute_script("$('.CodeMirror').hide();")
+
       click_button I18n.t('admin.buttons.save_changes')
     end
 
     def fill_in_all_required_fields
       select2('Parent Agency', 'org-name')
       fill_in 'location_name', with: 'New Parent Agency location'
-      fill_in 'location_description', with: 'new description'
+      fill_in_editor_field 'new description'
+      expect(page).to have_editor_display text: 'new description'
       click_link I18n.t('admin.buttons.add_street_address')
       fill_in 'location_address_attributes_address_1', with: '123 Main St.'
       fill_in 'location_address_attributes_city', with: 'Belmont'
       fill_in 'location_address_attributes_state_province', with: 'CA'
       fill_in 'location_address_attributes_postal_code', with: '12345'
       fill_in 'location_address_attributes_country', with: 'US'
+    end
+
+    def fill_in_editor_field(text)
+      within ".CodeMirror" do
+        current_scope.click
+        field = current_scope.find("textarea", visible: false)
+        field.send_keys text
+      end
+    end
+
+    def have_editor_display(options)
+      editor_display_locator = ".CodeMirror-code"
+      have_css(editor_display_locator, options)
     end
 
     def select2(value, id, options = {})


### PR DESCRIPTION
- [x]  Add `featured_at` column to locations table. Handle locations order based on `featured_at` and `covid19` data.
- [x] Remove old hardcoded logic for covid19
- [x] Add required spec for this order.
- [x] UI for featured checkbox

FIXED: ~Found that we already have some broken specs. Need to fix those in another branch.~