### PR TITLE
Add description to address details field

### DIFF
--- a/app/views/admin/services/forms/_address_details.html.haml
+++ b/app/views/admin/services/forms/_address_details.html.haml
@@ -1,6 +1,8 @@
 .inst-box
   %header
     = f.label :address_details
+    %p.desc
+      = t('.description')
 
   %p
     = f.text_area :address_details, class: 'form-control'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,7 +286,7 @@ en:
           description: 'A description of the service.'
 
         address_details:
-          description: 'Additional directions.'
+          description: 'Detailed geographic location of service. For example, "This pantry is located at 2500 North Avenue, Baltimore MD, 21219. It is on the 3rd floor in room 205"'
 
         eligibility:
           description: 'What criteria must served groups meet to receive service?'


### PR DESCRIPTION
## Summary
Adds a description to recently added Address Details field on Services 

**Files Modified**
- `en.yml`: updated description for address details
- `_address_details.html.haml`: added description to field

### Migrations to Run: No
