### PR TITLE
Allow address_details to be whitelisted in service params

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -160,7 +160,8 @@ class Admin
     def service_params
       update_archived_at_params
       params.require(:service).permit(
-        { accepted_payments: [] }, :alternate_name, :archived_at, :audience, :description, :eligibility, :email,
+        { accepted_payments: [] }, :alternate_name, :archived_at, :audience,
+        :description, :address_details, :eligibility, :email,
         :fees, { funding_sources: [] }, :application_process, :interpretation_services,
         { keywords: [] }, { tag_list: [] }, { languages: [] }, :name, { required_documents: [] },
         { service_areas: [] }, :status, :website, :wait_time, { category_ids: [] },


### PR DESCRIPTION
**In response to GH issue:** [123](https://github.com/bchd/bahc-ohana-api/issues/123)

**Files Modified**
- `app/controllers/admin/services_controller.rb`: Added `:address_details` to permitted params

**Migrations to Run:** No

**TODO**
- [ ] Test?
