### PR TITLE
Add a z-index to the savebar so it appears above the codemirror textbox

### DIFF
--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -267,6 +267,7 @@ a.boxed-action:active {
   position: fixed;
   right: 0;
   text-align: center;
+  z-index: 10;
 
   input {
     margin-bottom: 20px;


### PR DESCRIPTION
## Summary

Fixes the test suite to be green again. The z-index of codemirror was 1 which popped above the save bar which meant the save button wasn't clickable.