### PR TITLE
Zube 187 remove stop words

### DIFF
--- a/app/chewy/locations_index.rb
+++ b/app/chewy/locations_index.rb
@@ -1,16 +1,26 @@
 # frozen_string_literal: true
 class LocationsIndex < Chewy::Index
+
+  settings analysis: {
+    analyzer: {
+      remove_stop_words: {
+        type: "standard",
+        stopwords: "_english_"
+      }
+    }
+  }
+
   define_type Location.includes(:organization, :address, services: :categories) do
     field :accessibility
     field :archived_at, value: -> { archived_at? ? archived_at : nil }, type: 'date'
     field :archived, type: 'boolean', value: -> { !archived_at.nil? } 
     field :created_at, type: 'date'
-    field :description
+    field :description, analyzer: 'remove_stop_words'
     field :id, type: 'integer'
-    field :keywords, value: -> { services.map(&:keywords).compact.join(', ') }
-    field :name
+    field :keywords, value: -> { services.map(&:keywords).compact.join(', ') }, analyzer: 'remove_stop_words'
+    field :name, analyzer: 'remove_stop_words'
     field :organization_id, type: 'integer'
-    field :organization_name, value: -> { organization.try(:name) }
+    field :organization_name, value: -> { organization.try(:name) }, analyzer: 'remove_stop_words'
     field :updated_at, type: 'date'
     field :zipcode, value: -> { address.try(:postal_code) }
     field :category_ids, value: -> { services.map(&:categories).flatten.uniq.map(&:id) }

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -37,7 +37,7 @@ class LocationsSearch
       keyword_filter,
       zipcode_filter,
       category_filter,
-      accessibility_filter,
+      accessibility_filter, 
       order,
     ].compact.reduce(:merge)
   end
@@ -46,7 +46,8 @@ class LocationsSearch
     index.order(
       featured_at: { missing: "_last", order: "asc" },
       covid19: { missing: "_last", order: "asc" },
-      updated_at: { order: "desc" }
+      "_score": { "order": "desc" },
+      updated_at: { order: "desc" },
     )
   end
 
@@ -109,7 +110,6 @@ class LocationsSearch
       index.query(multi_match: {
                     query: keywords,
                     fields: %w[organization_name^3 name^2 description^1 keywords],
-                    analyzer: 'standard',
                     fuzziness: 'AUTO'
                   })
     end

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -80,6 +80,31 @@ RSpec.describe LocationsSearch, :elasticsearch do
       expect(results).not_to include(location_2, location_3)
     end
   end
+
+  describe 'location search' do
+    before do
+      @organization = create(:organization)
+      LocationsIndex.reset!
+    end
+  
+    it 'should return same results searching with and without stoping words' do
+      location_1 = create_location("Animal Shelter", @organization)
+      location_2 = create_location("Food and Shelter", @organization)
+      location_3 = create_location("This is a Featured location", @organization)
+  
+      import(location_1, location_2, location_3)
+  
+      results_no_stop_words = search({keywords: 'Animal Shelter'}).objects
+      expect(results_no_stop_words).to include(location_1)
+      expect(results_no_stop_words).to include(location_2)
+      expect(results_no_stop_words.size).to eq(2)
+  
+      results_with_stop_words = search({keywords: 'the Animal Shelter is an a'}).objects
+      expect(results_with_stop_words).to include(location_1)
+      expect(results_with_stop_words).to include(location_2)
+      expect(results_with_stop_words.size).to eq(2)
+    end
+  end
 end
 
 private


### PR DESCRIPTION
## Summary
this branch includes a new analyzer for the locations index that removes the stop words allowing to get the same results when searching for "Animal Shelter" or "The Animal Shelter is a an"

https://zube.io/smartlogic/bchd/c/187

Note: Run `rake chewy:reset`

### Tests to Run
- `spec/searches/location_search_spec.rb`: Third test added

### TODO
- [ ] Add UI Tests for Service Areas
- [ ] Possibly add model validation for areas
