### PR TITLE
Zube 222 return exact matches before partials

### DIFF
--- a/app/chewy/locations_index.rb
+++ b/app/chewy/locations_index.rb
@@ -18,7 +18,7 @@ class LocationsIndex < Chewy::Index
     field :description, analyzer: 'remove_stop_words'
     field :id, type: 'integer'
     field :keywords, value: -> { services.map(&:keywords).compact.join(', ') }, analyzer: 'remove_stop_words'
-    field :name, analyzer: 'remove_stop_words'
+    field :name, type: 'text', analyzer: 'remove_stop_words'
     field :name_exact, value: -> { name }
     field :organization_id, type: 'integer'
     field :organization_name, value: -> { organization.try(:name) }, analyzer: 'remove_stop_words'
@@ -28,8 +28,8 @@ class LocationsIndex < Chewy::Index
     field :zipcode, value: -> { address.try(:postal_code) }
     field :category_ids, value: -> { services.map(&:categories).flatten.uniq.map(&:id) }
     field :categories, value: -> { services.map(&:categories).flatten.uniq.map(&:name) }
-    field :categories_exact, type: 'keyword', value: -> { services.flat_map(&:categories).select { |cat| cat.ancestry.blank? }.uniq.map(&:name) }
-    field :sub_categories_exact, type: 'keyword', value: -> { services.flat_map(&:categories).select { |cat| !cat.ancestry.blank? }.uniq.map(&:name) }
+    field :categories_exact, value: -> { services.flat_map(&:categories).select { |cat| cat.ancestry.blank? }.uniq.map(&:name) }
+    field :sub_categories_exact, value: -> { services.flat_map(&:categories).select { |cat| !cat.ancestry.blank? }.uniq.map(&:name) }
     field :tags, value: -> { tags.map(&:name) }
     field :featured_at, type: 'date'
     field :covid19, value: -> { covid19? ? created_at : nil }, type: 'date'

--- a/app/chewy/locations_index.rb
+++ b/app/chewy/locations_index.rb
@@ -19,9 +19,11 @@ class LocationsIndex < Chewy::Index
     field :id, type: 'integer'
     field :keywords, value: -> { services.map(&:keywords).compact.join(', ') }, analyzer: 'remove_stop_words'
     field :name, analyzer: 'remove_stop_words'
+    field :name_exact, value: -> { name }
     field :organization_id, type: 'integer'
     field :organization_name, value: -> { organization.try(:name) }, analyzer: 'remove_stop_words'
     field :organization_tags, value: -> { organization.tags.pluck(:name) }
+    field :organization_name_exact, value: -> { organization.try(:name) }
     field :updated_at, type: 'date'
     field :zipcode, value: -> { address.try(:postal_code) }
     field :category_ids, value: -> { services.map(&:categories).flatten.uniq.map(&:id) }

--- a/app/chewy/locations_index.rb
+++ b/app/chewy/locations_index.rb
@@ -28,6 +28,8 @@ class LocationsIndex < Chewy::Index
     field :zipcode, value: -> { address.try(:postal_code) }
     field :category_ids, value: -> { services.map(&:categories).flatten.uniq.map(&:id) }
     field :categories, value: -> { services.map(&:categories).flatten.uniq.map(&:name) }
+    field :categories_exact, type: 'keyword', value: -> { services.flat_map(&:categories).select { |cat| cat.ancestry.blank? }.uniq.map(&:name) }
+    field :sub_categories_exact, type: 'keyword', value: -> { services.flat_map(&:categories).select { |cat| !cat.ancestry.blank? }.uniq.map(&:name) }
     field :tags, value: -> { tags.map(&:name) }
     field :featured_at, type: 'date'
     field :covid19, value: -> { covid19? ? created_at : nil }, type: 'date'

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -107,25 +107,29 @@ class LocationsSearch
       index.query(bool: {
                     should: [
                       { match_phrase: { "organization_name_exact": 
-                                      { query: keywords,
-                                        boost: 9
-                                      }
-                                  } },
+                                        { query: keywords,
+                                          boost: 9
+                                        }
+                                      } 
+                      },
                       { match_phrase: { "name_exact": 
-                                      { query: keywords,
-                                        boost: 8
-                                      }
-                                    } },
+                                        { query: keywords,
+                                          boost: 8
+                                        }
+                                      } 
+                      },
                       { match: { "categories_exact": 
-                                    { query: keywords,
-                                      boost: 7 
-                                    }
-                                  } },
+                                  { query: keywords,
+                                    boost: 7 
+                                  }
+                                } 
+                      },
                       { match: { "sub_categories_exact": 
                                   { query: keywords,
                                     boost: 6
                                   }
-                                } }
+                                } 
+                      }
                     ], 
                     must: {
                       multi_match: {

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -104,10 +104,26 @@ class LocationsSearch
 
   def keyword_filter
     if keywords?
-      index.query(multi_match: {
-                    query: keywords,
-                    fields: %w[organization_name^3 name^2 description^1 keywords categories tags organization_tags service_tags],
-                    fuzziness: 'AUTO'
+      index.query(bool: {
+                    should: [
+                      { match_phrase: { "organization_name_exact": 
+                                      { query: keywords,
+                                        boost: 6 
+                                      }
+                                  } },
+                      { match_phrase: { "name_exact": 
+                                      { query: keywords,
+                                        boost: 4 
+                                      }
+                                    } }
+                    ], 
+                    must: {
+                      multi_match: {
+                        query: keywords,
+                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags organization_tags service_tags],
+                        fuzziness: 'AUTO'
+                      }
+                    }
                   })
     end
   end

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -108,19 +108,29 @@ class LocationsSearch
                     should: [
                       { match_phrase: { "organization_name_exact": 
                                       { query: keywords,
-                                        boost: 6 
+                                        boost: 9
                                       }
                                   } },
                       { match_phrase: { "name_exact": 
                                       { query: keywords,
-                                        boost: 4 
+                                        boost: 8
                                       }
-                                    } }
+                                    } },
+                      { match: { "categories_exact": 
+                                    { query: keywords,
+                                      boost: 7 
+                                    }
+                                  } },
+                      { match: { "sub_categories_exact": 
+                                  { query: keywords,
+                                    boost: 6
+                                  }
+                                } }
                     ], 
                     must: {
                       multi_match: {
                         query: keywords,
-                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags organization_tags service_tags],
+                        fields: %w[organization_name^5 name^4 description^3 keywords categories tags organization_tags service_tags],
                         fuzziness: 'AUTO'
                       }
                     }

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -108,25 +108,25 @@ class LocationsSearch
                     should: [
                       { match_phrase: { "organization_name_exact": 
                                         { query: keywords,
-                                          boost: 9
+                                          boost: 20
                                         }
                                       } 
                       },
                       { match_phrase: { "name_exact": 
                                         { query: keywords,
-                                          boost: 8
+                                          boost: 19
                                         }
                                       } 
                       },
-                      { match: { "categories_exact": 
+                      { match_phrase: { "categories_exact": 
                                   { query: keywords,
-                                    boost: 7 
+                                    boost: 17
                                   }
                                 } 
                       },
-                      { match: { "sub_categories_exact": 
+                      { match_phrase: { "sub_categories_exact": 
                                   { query: keywords,
-                                    boost: 6
+                                    boost: 16
                                   }
                                 } 
                       }
@@ -134,7 +134,7 @@ class LocationsSearch
                     must: {
                       multi_match: {
                         query: keywords,
-                        fields: %w[organization_name^5 name^4 description^3 keywords categories tags organization_tags service_tags],
+                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags organization_tags service_tags],
                         fuzziness: 'AUTO'
                       }
                     }

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe LocationsSearch, :elasticsearch do
       location_organization_match = create_location("Organization name exact match", @org_exact_match)
       location_name_match = create_location("Financial Aid & Loans", @org)
       location_category_service_match = create_location("Location with Service category exact match", @org)
+      location_partial_match = create_location("Financial help and easy Loans", @org)
 
       service = create(:service, location: location_category_service_match, name: "Service category exact match")
       create(:category, services: [service], name: "Financial Aid & Loans")
@@ -32,6 +33,7 @@ RSpec.describe LocationsSearch, :elasticsearch do
       expect(results.second.id).to be(location_organization_match.id)
       expect(results.third.id).to be(location_name_match.id)
       expect(results.fourth.id).to be(location_category_service_match.id)
+      expect(results.fifth.id).to be(location_partial_match.id)
     end
   end
 

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-
+require 'pry'
 RSpec.describe LocationsSearch, :elasticsearch do
   def search(attributes = {})
     described_class.new(attributes).search.load
@@ -12,22 +12,22 @@ RSpec.describe LocationsSearch, :elasticsearch do
   describe 'top order of exact matches' do
     specify 'Exact Matches should be ordered like this: (after featured) 1.Organization Name 2.Location Name 3.Service Category 4.Service Subcategory' do
 
-      @org_exact_match = create(:organization, name: 'Financial Aid & Loans')
+      @org_exact_match = create(:organization, name: 'Financial Aid And Loans')
       @org = create(:organization, name: 'Regular Name')
       LocationsIndex.reset!
 
-      featured_location = create_location("financial aid & nice loans", @org, "1")
+      featured_location = create_location("financial aid and nice loans", @org, "1")
       location_organization_match = create_location("Organization name exact match", @org_exact_match)
-      location_name_match = create_location("Financial Aid & Loans", @org)
+      location_name_match = create_location("Financial Aid And Loans", @org)
       location_category_service_match = create_location("Location with Service category exact match", @org)
-      location_partial_match = create_location("Financial help and easy Loans", @org)
+      location_partial_match = create_location("Financial help and super easy fast Loans", @org)
 
-      service = create(:service, location: location_category_service_match, name: "Service category exact match")
-      create(:category, services: [service], name: "Financial Aid & Loans")
+      service_exact_match = create(:service, location: location_category_service_match, name: "Service category exact match")
+      category_exact_match = create(:category, services: [service_exact_match], name: "Financial Aid And Loans")
 
-      import(featured_location, location_organization_match, location_name_match, location_category_service_match)
+      import(featured_location, location_organization_match, location_name_match, location_category_service_match,location_partial_match)
 
-      results = search({keywords: 'Financial Aid & Loans'}).objects
+      results = search({keywords: 'Financial Aid And Loans'}).objects
 
       expect(results.first.id).to be(featured_location.id)
       expect(results.second.id).to be(location_organization_match.id)

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -9,6 +9,30 @@ RSpec.describe LocationsSearch, :elasticsearch do
     LocationsIndex.import!(*args)
   end
 
+  describe 'top order of exact matches' do
+    specify 'Exact Matches should be ordered like this: 1.Organization Name 2.Location Name 3.Service Category 4.Service Subcategory' do
+
+      @org_exact_match = create(:organization, name: 'Financial Aid & Loans')
+      @org = create(:organization, name: 'Regular Name')
+      LocationsIndex.reset!
+
+      location_organization_match = create_location("Organization name exact match", @org_exact_match)
+      location_name_match = create_location("Financial Aid & Loans", @org)
+      location_category_service_match = create_location("Location with Service category exact match", @org)
+
+      service = create(:service, location: location_category_service_match, name: "Service category exact match")
+      create(:category, services: [service], name: "Financial Aid & Loans")
+
+      import(location_organization_match, location_name_match, location_category_service_match)
+
+      results = search({keywords: 'Financial Aid & Loans'}).objects
+
+      expect(results.first.id).to be(location_organization_match.id)
+      expect(results.second.id).to be(location_name_match.id)
+      expect(results.third.id).to be(location_category_service_match.id)
+    end
+  end
+
   describe 'by organization name' do 
     before do
       @org1 = create(:organization, name: 'Partial Match on Org Name DRUG COMPANY')


### PR DESCRIPTION
## Summary
Adds display priority to exact matches in the follwing order: 

Featured 

1. Org name exact match
2. Location name exact match
3. Service category exact match
4. Service sub-category exact match

https://zube.io/smartlogic/bchd/c/222

**Files Modified**
- 

### Migrations to Run: Yes / No
Reset Chewy 

### Tests to Run
- spec/searches/locations_search_spec.rb

### TODO
- [ ] Add UI Tests for Service Areas
- [ ] Possibly add model validation for areas
