### PR TITLE
224 tagged result sorting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :test, :development do
   gem 'bullet'
   gem 'byebug'
   gem 'factory_bot_rails'
+  gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
   gem 'rspec-its'
   gem 'rspec-rails', '~> 4.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/faker-ruby/faker.git
+  revision: ec06d217644cf3d66bd0e658c9b168af8f0c38c7
+  branch: master
+  specs:
+    faker (2.15.1)
+      i18n (>= 1.6, < 2)
+
+GIT
   remote: https://github.com/lpender/bummr.git
   revision: 6ededf2436586153834be95f212f11c663aa5040
   specs:
@@ -483,6 +491,7 @@ DEPENDENCIES
   devise (~> 4.7)
   enumerize
   factory_bot_rails
+  faker!
   fastimage
   figaro (~> 1.0)
   flamegraph

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -135,7 +135,7 @@ class LocationsSearch
                     must: {
                       multi_match: {
                         query: keywords,
-                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags organization_tags^2 service_tags],
+                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags^2 organization_tags^3 service_tags],
                         fuzziness: 'AUTO'
                       }
                     }

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -130,11 +130,12 @@ class LocationsSearch
                                   }
                                 } 
                       }
+
                     ], 
                     must: {
                       multi_match: {
                         query: keywords,
-                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags organization_tags service_tags],
+                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags organization_tags^2 service_tags],
                         fuzziness: 'AUTO'
                       }
                     }

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :location do
-    name { 'VRS Services' }
+    name { Faker::Movies::HarryPotter.location }
     description { 'Provides jobs training' }
     short_desc { 'short description' }
     accessibility { %i[tape_braille disabled_parking] }

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :location do
-    name { Faker::Movies::HarryPotter.location }
+    name { 'VRS Services' }
     description { 'Provides jobs training' }
     short_desc { 'short description' }
     accessibility { %i[tape_braille disabled_parking] }

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,16 +1,13 @@
 FactoryBot.define do
   factory :tag, class: Tag do
-    id { 1 }
     name { 'Education' }
   end
 
   factory :tag_org, class: Tag do
-    id { 2 }
     name { 'Organization_tag' }
   end
 
   factory :tag_service, class: Tag do
-    id { 3 }
     name { 'Service_tag' }
   end
 end

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -423,20 +423,32 @@ RSpec.describe LocationsSearch, :elasticsearch do
       organization = create(:organization, name: 'Definitely doesnt contain terms')
       organization.tags << tag_1
       organization.tags << tag_2
+      #
+      # 1. Associated org with tags containing “Salvation” tag AND “Army” tag
       location_1 = create(:location, organization: organization)
 
-      # creates location with BOTH tags
-
-      location_2 = create_location("Location with BOTH tags", @organization)
+      # creates location with FIRST tag
+      # 2. Location contains "Salvation" tag AND associated service contains "Army" tag
+      location_2 = create_location("Location with one tag", @organization)
       location_2.tags << tag_1
-      location_2.tags << tag_2
 
-      import(location_1, location_2)
+      # and service on that location with the second tag!
+      service_with_second_tag = create(:service, location: location_2)
+      service_with_second_tag.tags << tag_2
+
+      # create location with service with tag 1 and a different service with tag 2
+      location_3 = create_location("Neither tag", @organization)
+      service_with_first_tag = create(:service, location: location_3)
+      service_with_first_tag.tags << tag_1
+      another_service_with_second_tag = create(:service, location: location_3)
+
+      import(location_1, location_2, location_3)
 
       results = search({keywords: "#{term_1} #{term_2}"}).objects
 
       expect(results.first.id).to eq(location_1.id)
       expect(results.second.id).to eq(location_2.id)
+      expect(results.third.id).to eq(location_3.id)
     end
 
     it 'sorts tagged result prioritizing LOCATION AND TAGS' do

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -455,10 +455,6 @@ RSpec.describe LocationsSearch, :elasticsearch do
       expect(results.third.id).to eq(location_3.id)
       expect(results.fourth.id).to eq(location_4.id)
     end
-
-    it 'sorts tagged result prioritizing LOCATION AND TAGS' do
-
-    end
   
     it 'should return locations matching the location - tags' do
       # tag name (Education) taken from tags factory
@@ -494,7 +490,6 @@ RSpec.describe LocationsSearch, :elasticsearch do
       expect(results).to include(location_1)
       expect(results.size).to eq(1)
     end
-
   end
 end
 

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -405,14 +405,12 @@ RSpec.describe LocationsSearch, :elasticsearch do
       expect(results.size).to eq(2)
     end
 
-    # 1. Associated org with tags containing “Salvation” tag AND “Army” tag
-    # 2. Location contains "Salvation" tag AND associated service contains "Army" tag
     # 3. Associated service contains "Salvation" tag AND another associated service contains "Army" tag
     # 4. Services with tags containing “Salvation” OR “Army”
     # 5. Locations with tags containing “Salvation” OR “Army”
     # 6. Associated org with tags containing “Salvation” OR “Army”
 
-    it 'sorts tagged result prioritizing ORGANIZATION AND TAGS #1' do
+    it 'sorts tagged results' do
       term_1 = "Salvation"
       term_2 = "Army"
 

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -405,8 +405,6 @@ RSpec.describe LocationsSearch, :elasticsearch do
       expect(results.size).to eq(2)
     end
 
-    # 3. Associated service contains "Salvation" tag AND another associated service contains "Army" tag
-    # 4. Services with tags containing “Salvation” OR “Army”
     # 5. Locations with tags containing “Salvation” OR “Army”
     # 6. Associated org with tags containing “Salvation” OR “Army”
 
@@ -421,6 +419,7 @@ RSpec.describe LocationsSearch, :elasticsearch do
       organization = create(:organization, name: 'Definitely doesnt contain terms')
       organization.tags << tag_1
       organization.tags << tag_2
+
       #
       # 1. Associated org with tags containing “Salvation” tag AND “Army” tag
       location_1 = create(:location, organization: organization)
@@ -435,18 +434,26 @@ RSpec.describe LocationsSearch, :elasticsearch do
       service_with_second_tag.tags << tag_2
 
       # create location with service with tag 1 and a different service with tag 2
+      # 3. Associated service contains "Salvation" tag AND another associated service contains "Army" tag
       location_3 = create_location("Neither tag", @organization)
       service_with_first_tag = create(:service, location: location_3)
+      service_with_second_tag_2 = create(:service, location: location_3)
       service_with_first_tag.tags << tag_1
-      another_service_with_second_tag = create(:service, location: location_3)
+      service_with_second_tag_2.tags << tag_2
+      
+      # 4. Services with tags containing “Salvation” OR “Army”
+      location_4 = create_location("Single matching tag on service", @organization)
+      service_with_matching_tag = create(:service, location: location_4)
+      service_with_matching_tag.tags << tag_2
 
-      import(location_1, location_2, location_3)
+      import(location_1, location_2, location_3, location_4)
 
       results = search({keywords: "#{term_1} #{term_2}"}).objects
 
       expect(results.first.id).to eq(location_1.id)
       expect(results.second.id).to eq(location_2.id)
       expect(results.third.id).to eq(location_3.id)
+      expect(results.fourth.id).to eq(location_4.id)
     end
 
     it 'sorts tagged result prioritizing LOCATION AND TAGS' do


### PR DESCRIPTION
AC:
Verify that TAGGED resource results are sorted in the following order:

- [x] Verify that tagges matches are sorted **after** partial matches.
- [x] Verify the following sort order for tagged matches
- [x] 1. Associated org with tags containing “Salvation” tag AND “Army” tag
- [x] 2. Location contains "Salvation" tag AND associated service contains "Army" tag
- [x] 3. Services with tags containing “Salvation” OR “Army”
- [x] 4. Locations with tags containing “Salvation” OR “Army”
- [x] Verify that tagged matches are sorted **before** AND matches.


### Sort Priority Example
![Charmcare—Sort priority 1.jpg](https://zube.io/files/smartlogic/994ce752cc436a3a0c1ad2603c290271-charmcaresort-priority-1.jpg)