### PR TITLE
Zube - 225 - AND results order 

### DIFF
--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -129,17 +129,12 @@ class LocationsSearch
                                     boost: 40
                                   }
                                 } 
-                      },
-                      { multi_match: {
-                        query: keywords,
-                        fields: %w[description^3 service_names^2 service_descriptions],
-                        fuzziness: 'AUTO'
-                      } }
+                      }
                     ],
                     must: {
                       multi_match: {
                         query: keywords,
-                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags^2 organization_tags^3 service_tags service_names^1 service_descriptions],
+                        fields: %w[organization_name^10 name^9 categories^8 organization_tags^7 service_tags^6 tags^5 description^4 service_names^3 service_descriptions^2 keywords],
                         fuzziness: 'AUTO'
                       }
                     }


### PR DESCRIPTION
## Summary
It is intended to incorporate AND matching results in the right order for the following fields:

Location description containing “Salvation” AND “Army”
Service name containing “Salvation” AND “Army”
Service description containing “Salvation” AND “Army”
Location description contains "Salvation" AND associated service contains "Army"

**Zube Card Referenced** 255
https://zube.io/smartlogic/bchd/c/225

**Files Modified**
- `locations_search.rb`
- `locations_search_spec.rb`

### Tests to Run
- `/spec/searches/locations_search_spec.rb`

