### PR TITLE
Zube 225 

### DIFF
--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -129,17 +129,12 @@ class LocationsSearch
                                     boost: 40
                                   }
                                 } 
-                      },
-                      { multi_match: {
-                        query: keywords,
-                        fields: %w[description^3 service_names^2 service_descriptions],
-                        fuzziness: 'AUTO'
-                      } }
+                      }
                     ],
                     must: {
                       multi_match: {
                         query: keywords,
-                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags^2 organization_tags^3 service_tags service_names^1 service_descriptions],
+                        fields: %w[organization_name^10 name^9 categories^8 organization_tags^7 service_tags^6 tags^5 description^4 service_names^3 service_descriptions^2 keywords],
                         fuzziness: 'AUTO'
                       }
                     }

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -129,7 +129,12 @@ class LocationsSearch
                                     boost: 40
                                   }
                                 } 
-                      }
+                      },
+                      { multi_match: {
+                        query: keywords,
+                        fields: %w[description^3 service_names^2 service_descriptions],
+                        fuzziness: 'AUTO'
+                      } }
                     ],
                     must: {
                       multi_match: {

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -139,7 +139,7 @@ class LocationsSearch
                     must: {
                       multi_match: {
                         query: keywords,
-                        fields: %w[organization_name^10 name^9 categories^8 organization_tags^7 service_tags^6 tags^5 description^4 service_names^3 service_descriptions^2 keywords],
+                        fields: %w[organization_name^3 name^2 description^1 keywords categories tags^2 organization_tags^3 service_tags service_names^1 service_descriptions],
                         fuzziness: 'AUTO'
                       }
                     }

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -432,44 +432,16 @@ RSpec.describe LocationsSearch, :elasticsearch do
       location_service_dec_and_match = create_location("Match in Service description", @organization)
       service_dec_and_match = create(:service, location: location_service_dec_and_match, description: "Service Description containing both terms: #{keywords}")
 
-      import(location_desc_and_match, location_service_name_and_match, location_service_dec_and_match)
-      results = search({keywords: "#{term_1} #{term_2}"}).objects
-      expect(results.first.id).to eq(location_desc_and_match.id)
-      expect(results.second.id).to eq(location_service_name_and_match.id)
-      expect(results.third.id).to eq(location_service_dec_and_match.id)
-    end
+      location_random_terms = create_location("Random location", @organization)
 
-    it 'sorts results containing both 2 terms before results containign one term' do
+      import(location_desc_and_match, location_service_name_and_match, location_service_dec_and_match, location_random_terms)
 
-      term_1 = "Salvation"
-      term_2 = "Army"
-      terms = [term_1, term_2]
-      keywords = terms.join(" ")
-
-      location_desc_and_match = create_location("AND Match in Description", @organization)
-      location_desc_and_match.update_columns(description: "This description contains both terms: #{keywords}")
-
-      location_service_name_and_match = create_location("AND Match in Service Name", @organization)
-      service_name_and_match = create(:service, location: location_service_name_and_match, name: "Service Name containing both terms: #{keywords}")
-
-      location_service_dec_and_match = create_location("AND Match in Service description", @organization)
-      service_dec_and_match = create(:service, location: location_service_dec_and_match, description: "Service Description containing both terms: #{keywords}")
-
-      location_1 = create_location("OR Match in Description", @organization)
-      location_1.update_columns(description: "This description contains one of the two terms: #{terms[rand(0..1)]}")
-
-      location_2 = create_location("OR Match in Service Name", @organization)
-      service_1 = create(:service, location: location_2, name: "Service Name containing one of the terms: #{terms[rand(0..1)]}")
-
-      location_3 = create_location("OR Match in Service description", @organization)
-      service_2 = create(:service, location: location_3, description: "Service Description containing one of the terms: #{terms[rand(0..1)]}")
-
-      import(location_desc_and_match, location_service_name_and_match, location_service_dec_and_match, location_1, location_2, location_3)
       results = search({keywords: "#{term_1} #{term_2}"}).objects
 
       expect(results.first.id).to eq(location_desc_and_match.id)
       expect(results.second.id).to eq(location_service_name_and_match.id)
       expect(results.third.id).to eq(location_service_dec_and_match.id)
+      expect(results).not_to include(location_random_terms)
     end
 
     it 'sorts results containing 1 of 2 terms' do


### PR DESCRIPTION
## Summary
It is intended to incorporate AND matching results in the right order for the following fields:

Location description containing “Salvation” AND “Army”
Service name containing “Salvation” AND “Army”
Service description containing “Salvation” AND “Army”
Location description contains "Salvation" AND associated service contains "Army"

**Zube Card Referenced** 255
https://zube.io/smartlogic/bchd/c/225

**Files Modified**
- `locations_search.rb`
- `locations_search_spec.rb`

### Tests to Run
- `/spec/searches/locations_search_spec.rb`