### PR TITLE
Zube 238 and Zube 237 - Remove covid sort from search query and Fix flaky tests

### DIFF
--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -134,7 +134,7 @@ class LocationsSearch
                       {
                         multi_match: {
                           query: keywords,
-                          fields: %w[organization_name^18 name^16 categories^14 organization_tags^12 tags^10 service_tags^8 description^6 service_names^4 service_descriptions^2 keywords],
+                          fields: %w[organization_name^20 name^16 categories^14 organization_tags^12 tags^10 service_tags^8 description^6 service_names^4 service_descriptions^2 keywords],
                           fuzziness: 'AUTO'
                         }
                       }

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -45,7 +45,6 @@ class LocationsSearch
   def order
     index.order(
       featured_at: { missing: "_last", order: "asc" },
-      covid19: { missing: "_last", order: "asc" },
       "_score": { "order": "desc" },
       updated_at: { order: "desc" },
     )

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -519,7 +519,7 @@ describe "GET 'search'" do
     before do
       @organization = create(:organization)
 
-      @loc1 = create_location("Not featured and not covid", @organization)
+      @loc1 = create_location("Not featured", @organization)
       @loc2 = create_location("featured location", @organization, "1")
 
       LocationsIndex.reset!

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -519,17 +519,15 @@ describe "GET 'search'" do
     before do
       @organization = create(:organization)
 
-      @loc1 = create_location("covid location", @organization)
-      @loc2 = create_location("Not featured and not covid", @organization)
-      @loc3 = create_location("featured location", @organization, "1")
+      @loc1 = create_location("Not featured and not covid", @organization)
+      @loc2 = create_location("featured location", @organization, "1")
 
       LocationsIndex.reset!
     end
 
-    it 'it should return featured locations first, second covid19 locations, and then the rest' do
+    it 'it should return featured locations first, and then the rest' do
       expect(@loc1.organization.name).to eq('Parent Agency')
       expect(@loc2.organization.name).to eq('Parent Agency')
-      expect(@loc3.organization.name).to eq('Parent Agency')
 
       LocationsIndex.reset!
 
@@ -537,17 +535,15 @@ describe "GET 'search'" do
 
       sleep 0.5
 
-      expect(json[0]['name']).to eq(@loc3.name)
+      expect(json[0]['name']).to eq(@loc2.name)
       expect(json[1]['name']).to eq(@loc1.name)
-      expect(json[2]['name']).to eq(@loc2.name)
     end
 
-    it 'it should return locations order based on updated_at property if no featured_at and covid19 locations' do
+    it 'it should return locations order based on updated_at property if no featured_at' do
       time = Time.current
 
-      @loc1.update_columns(name: "regular location1", updated_at: time - 5.minutes)
-      @loc2.update_columns(name: "regular location2", updated_at: time - 3.minutes)
-      @loc3.update_columns(name: "regular location3", featured_at: time, updated_at: time - 1.minutes)
+      @loc1.update_columns(name: "regular location2", updated_at: time - 3.minutes)
+      @loc2.update_columns(name: "regular location3", featured_at: time, updated_at: time - 1.minutes)
 
       LocationsIndex.reset!
 
@@ -555,9 +551,8 @@ describe "GET 'search'" do
 
       sleep 0.5
 
-      expect(json[0]['name']).to eq(@loc3.name)
-      expect(json[1]['name']).to eq(@loc2.name)
-      expect(json[2]['name']).to eq(@loc1.name)
+      expect(json[0]['name']).to eq(@loc2.name)
+      expect(json[1]['name']).to eq(@loc1.name)
     end
   end
 end

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -483,6 +483,14 @@ RSpec.describe LocationsSearch, :elasticsearch do
 
       location_random_terms = create_location("Random location", @organization)
 
+      time = Time.current
+
+      # Set for all of them the same updated_at time stamp so they get ordered only considering score
+      location_desc_and_match.update_columns(updated_at: time)
+      location_service_name_and_match.update_columns(updated_at: time)
+      location_service_dec_and_match.update_columns(updated_at: time)
+      location_random_terms.update_columns(updated_at: time)
+
       import(location_desc_and_match, location_service_name_and_match, location_service_dec_and_match, location_random_terms)
 
       results = search({keywords: "#{term_1} #{term_2}"}).objects
@@ -512,6 +520,13 @@ RSpec.describe LocationsSearch, :elasticsearch do
 
       location_3 = create_location("Match in Service description", @organization)
       service_2 = create(:service, location: location_3, description: "Service Description containing one of the terms: #{terms[rand(0..1)]}")
+
+      time = Time.current
+
+      # Set for all of them the same updated_at time stamp so they get ordered only considering score
+      location_1.update_columns(updated_at: time)
+      location_2.update_columns(updated_at: time)
+      location_3.update_columns(updated_at: time)
 
       import(location_1, location_2, location_3)
 

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe LocationsSearch, :elasticsearch do
       service_sub_cat = create(:service, location: location_sub_category_service_match, name: "Service sub category exact match")
       sub_cat = create(:financial_aid, services: [service_sub_cat])
 
+      time = Time.current
+      
+      # Set for all of them the same updated_at time stamp so they get ordered only considering score
+      featured_location.update_columns(updated_at: time)
+      location_organization_match.update_columns(updated_at: time)
+      location_name_match.update_columns(updated_at: time)
+      location_category_service_match.update_columns(updated_at: time)
+      location_partial_match.update_columns(updated_at: time)
+      location_sub_category_service_match.update_columns(updated_at: time)
+
       import(featured_location, location_organization_match, location_name_match, location_category_service_match, location_partial_match, location_sub_category_service_match)
 
       results = search({keywords: 'Financial Aid And Loans'}).objects
@@ -89,6 +99,13 @@ RSpec.describe LocationsSearch, :elasticsearch do
 
       service = create(:service, location: location_3, name: "Service with matching terms on category name")
       create(:category, services: [service], name: "Catgory for DRUG COMPANY supplies")
+
+      time = Time.current
+
+      # Set for all of them the same updated_at time stamp so they get ordered only considering score
+      location_1.update_columns(updated_at: time)
+      location_2.update_columns(updated_at: time)
+      location_3.update_columns(updated_at: time)
 
       import(location_1, location_2, location_3)
 


### PR DESCRIPTION
## Summary
238 - Remove covid sort from query so users don't see unrelated location results on top of relevant location results.
237 - Fix flaky tests 

**Zube Card Referenced** 
https://zube.io/smartlogic/bchd/c/238
https://zube.io/smartlogic/bchd/c/237

**Files Modified**
- `app/searches/location_search.rb`: Removed covid sort
- `spec/api/search_spec.rb`: Removed covid sort related test
- `spec/searches/locations_search_spec.rb`: Fix flaky tests and added tests covering the general sort order

