### PR TITLE
add update_index function missing

### DIFF
--- a/app/chewy/services_index.rb
+++ b/app/chewy/services_index.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ServicesIndex < Chewy::Index
-  define_type Service.includes(:location) do
+  define_type Service.includes(:location, :tags) do
     field :archived_at, type: 'date'
     field :archived, type: 'boolean', value: -> { !archived_at.nil? } 
     field :id, type: 'integer'

--- a/app/models/tag_resource.rb
+++ b/app/models/tag_resource.rb
@@ -1,4 +1,16 @@
 class TagResource < ApplicationRecord
+  # We want to skip organization because the index does not exist
+  # Keep this up to date with any taggable resource
+  update_index(-> (tag_resource) {
+    case tag_resource.resource_type 
+    when "Location" then "locations#location"
+    when "Service" then "services#service"
+    end
+  }) do
+    return nil if self.resource_type == "Organization"
+    self.resource
+  end
+
   belongs_to :tag
   belongs_to :resource, polymorphic: true
 

--- a/app/models/tag_resource.rb
+++ b/app/models/tag_resource.rb
@@ -1,6 +1,4 @@
 class TagResource < ApplicationRecord
-  # We want to skip organization because the index does not exist
-  # Keep this up to date with any taggable resource
   
   belongs_to :tag
   belongs_to :resource, polymorphic: true, touch: true

--- a/app/models/tag_resource.rb
+++ b/app/models/tag_resource.rb
@@ -1,18 +1,9 @@
 class TagResource < ApplicationRecord
   # We want to skip organization because the index does not exist
   # Keep this up to date with any taggable resource
-  update_index(-> (tag_resource) {
-    case tag_resource.resource_type 
-    when "Location" then "locations#location"
-    when "Service" then "services#service"
-    end
-  }) do
-    return nil if self.resource_type == "Organization"
-    self.resource
-  end
-
+  
   belongs_to :tag
-  belongs_to :resource, polymorphic: true
+  belongs_to :resource, polymorphic: true, touch: true
 
   def self.get_resources (tag_id)
     where("tag_id = ?", tag_id).select(:resource_id, :resource_type)


### PR DESCRIPTION
## Summary
Small change intended to update the location search when a Tag is deleted.

Before: The search on the ui were displaying locations attached to a tag even after the tag was deleted (even though the location didn't contain the tag tag)

Now: Every time a tag is deleted, the corresponding ElasticSearch documents get updated accordingly to display accurate search results. 
