### PR TITLE
Adds archived service filter to categories sql

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -18,6 +18,7 @@ class Category < ApplicationRecord
   def self.unarchived
     Category.
       joins(services: :location).
+      where(services: { archived_at: nil }).
       where(services: { locations: { archived_at: nil } }).
       distinct.order(:name)
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -18,8 +18,7 @@ class Category < ApplicationRecord
   def self.unarchived
     Category.
       joins(services: :location).
-      where(services: { archived_at: nil }).
-      where(services: { locations: { archived_at: nil } }).
+      where(services: { archived_at: nil, locations: { archived_at: nil } }).
       distinct.order(:name)
   end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -16,4 +16,28 @@ describe Category do
     is_expected.to validate_uniqueness_of(:taxonomy_id).
       case_insensitive.with_message('id has already been taken')
   end
+
+  describe ".unarchived" do
+    it "dont show category that only has archived services" do
+      category_with_archived_service = create(:category)
+      category_with_archived_service.services << create(:service, archived_at: DateTime.now)
+      expect(Category.unarchived).not_to include(category_with_archived_service)
+    end
+
+    it "dont show category that only has services that belong to archived locations" do
+      category_with_archived_location = create(:category)
+      archived_location = create(:location, archived_at: DateTime.now)
+      unarchived_service_with_archived_location = create(:service, location: archived_location)
+      category_with_archived_location.services << unarchived_service_with_archived_location
+      expect(Category.unarchived).not_to include(category_with_archived_location)
+    end
+
+    it "includes categories with unarchived locations with unarchived services associated with the category" do
+      good_category = create(:category)
+      good_location = create(:location)
+      good_service = create(:service, location: good_location)
+      good_category.services << good_service
+      expect(Category.unarchived).to include(good_category)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
The categories API should return categories where there are UNARCHIVED Locations that have UNARCHIVED Services that are associated with that category.

**Files Modified**
- `app/models/category.rb`: Adds unarchived service clause to the categories query

### Migrations to Run: No

### TODO
- [x] Modify model spec
