### PR TITLE
Removes unnecessary services from service categories report

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -22,7 +22,7 @@ class Service < ApplicationRecord
 
   belongs_to :location, touch: true, optional: false
   belongs_to :program, touch: true
-  scope :unarchived, -> { where(archived_at: nil)}
+  scope :unarchived, -> { includes(:location).where(archived_at: nil, locations: { archived_at: nil }) }
   has_and_belongs_to_many :categories,
                           after_add: :touch_location,
                           after_remove: :touch_location

--- a/app/views/admin/csv/service_categories.csv.shaper
+++ b/app/views/admin/csv/service_categories.csv.shaper
@@ -1,6 +1,6 @@
 csv.headers :current_parent_categories, :name, :id, :location_name, :new_category, :new_subcategory, :clear_categories
 
-csv.rows Service.where(archived_at: nil) do |csv, service|
+csv.rows Service.unarchived do |csv, service|
   csv.cell :current_parent_categories
   csv.cell :name
   csv.cell :id


### PR DESCRIPTION
## Summary
Optimizing the service categories report to prevent timeouts with lots of services 

**Files Modified**
- `app/models/service.rb`: Removes archived locations from service reporter

### Migrations to Run: No

### TODO
- [ ] Possibly add spec for the reporter
