### PR TITLE
Adds rake task to remove orphaned categories

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,14 @@
+namespace :cleanup do
+  desc 'Destroys orphaned categories'
+  task :categories, [:args] => :environment do |_, args|
+    categories_to_destroy = Category.includes(:services).select{|c| c.services.length == 0}
+    STDOUT.puts "Are you sure you want to destroy #{categories_to_destroy.count} categories? (only 'yes' will continue)"
+    are_you_sure = STDIN.gets.strip
+    if are_you_sure == 'yes'
+      puts "Destroying categories without services"
+      categories_to_destroy.each do |c|
+        c.destroy
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds a rake task to remove orphaned categories (categories with no services)

**File Addition(s)** 
- `lib/tasks/cleanup.rake`: The rake task

### Migrations to Run: No

### TODO
- [ ] Write it in SQL?
