### PR TITLE
add category ids to create action

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -101,6 +101,7 @@ class Admin
       @location = Location.find(params[:location_id])
       @service = @location.services.new(service_params.except(:locations))
       @taxonomy_ids = []
+      @category_ids = service_params[:category_ids]
 
       authorize @location
       preprocess_service


### PR DESCRIPTION
## Summary
intended to fix [this sentry error](https://sentry.io/organizations/smartlogic/issues/2349709968/?project=5339670&query=is%3Aunresolved)
The bug is caused by the failure of the create action to save the new service, which then renders the services/new template. There was no category_ids local variable set in the create action so the template errored out. I set the variable with category ids from the incoming service_params (instead of with an empty array like is used in the 'new' action) 

**Files Modified**
- `services_controller.rb`: Added '@category_ids' variable to 'prepare_and_authorize_service_creation' called by create action

### Migrations to Run: No

note: I wasn't able to reproduce the bug (it's caused by the failure of a resource to save, every time I tried reproducing that behavior I got regular validation errors and such) please let me know if there's a technique for reproducing this error
