### PR TITLE
check for empty geocoder response

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -90,9 +90,11 @@ module Api
         address = params[:address]
         if address.present? && address != "Current Location"
           response = Geocoder.search(params[:address])
-          coordinates = response.first.data['geometry']['location']
-          @lat = coordinates['lat']
-          @lon = coordinates['lng']
+          unless response.empty?
+            coordinates = response.first.data['geometry']['location']
+            @lat = coordinates['lat']
+            @lon = coordinates['lng']
+          end  
         elsif params[:lat].present? && params[:long]
           @lat = params[:lat]
           @lon = params[:long]


### PR DESCRIPTION
## Summary
fixes [this bug](https://sentry.io/organizations/smartlogic/issues/2302333669/events/latest/?project=5339670&referrer=slack)

**Files Modified**
- app/controllers/api/v1/search_controller.rb - added a check for empty geocoder response

### Migrations to Run: No