### PR TITLE
show all available categories in admin form

### DIFF
--- a/app/views/admin/services/forms/_categories.html.haml
+++ b/app/views/admin/services/forms/_categories.html.haml
@@ -9,4 +9,4 @@
   = field_set_tag nil, id: 'categories' do
     = f.label :services
     = categories_expand_button
-    = nested_categories(Category.unarchived.arrange(order: :name))
+    = nested_categories(Category.all.arrange(order: :name))


### PR DESCRIPTION
## Summary
allows all available categories to be seen and selected in the admin form view.
Previously only those that were already linked to a service were shown, so it was impossible to create a new category and then add it to a service from the admin form. 
The public UI is unchanged and users will still only see categories that have been attached to a service. 

**Zube Card Referenced** 280

**Files Modified**
- app/views/admin/services/forms/_categories.html.haml

### Migrations to Run: No

### TODO
create and rename categories in the production DB as described in the 280 zube card (the correct rails console commands are in the zube comments)
