### PR TITLE
Viewing a location does not use api

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -70,6 +70,7 @@ class LocationsController < ApplicationController
 
     # @keywords = @location.services.map { |s| s[:keywords] }.flatten.compact.uniq
     @categories = @location.services.map { |s| s[:categories] }.flatten.compact.uniq
+    @url = request.url
   end
 
   # Ajax response to update the exanded div listing subcategories

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -251,6 +251,15 @@ class Location < ApplicationRecord
   # @param id [String] Location id.
   # @return [Sawyer::Resource] Hash of location details.
   def self.get(id)
-    Ohanakapa.location(id)
+    location = Location.includes(
+      :file_uploads,
+      services: [:categories],
+      contacts: :phones
+    ).find(id)
+  end
+
+  def coordinates
+    return [] unless self.longitude.present? && self.latitude.present?
+    [self.longitude, self.latitude]
   end
 end

--- a/app/views/component/detail/_service_categories.html.haml
+++ b/app/views/component/detail/_service_categories.html.haml
@@ -1,4 +1,4 @@
-- service_categories = service[:categories].select { |c| c[:type] == 'service' }
+- service_categories = service.categories.select { |c| c[:type] == 'service' }
 - if service_categories.present?
   - sorted_categories = service_categories.sort { |a, b| a[:id].to_i - b[:id].to_i }
   %section.service-categories-box

--- a/app/views/component/detail/_service_situations_group.html.haml
+++ b/app/views/component/detail/_service_situations_group.html.haml
@@ -1,5 +1,5 @@
 - regex = %r/\A#{taxonomy_id}-.*/
-- situation_categories = service[:categories].select { |c| regex.match c[:taxonomy_id] }
+- situation_categories = service.categories.select { |c| regex.match c[:taxonomy_id] }
 - if situation_categories.present?
   - sorted_categories = situation_categories.sort { |a, b| a[:id].to_i - b[:id].to_i }
   %section.situation-categories-box

--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -173,7 +173,7 @@
     var userId = #{@current_user_id};
     var locationId = #{@location.id};
     var locationName = "#{@location.name}";
-    var locationUrl = "#{@location.url}";
+    var locationUrl = "{@url}";
     var favoriteText = "favorite";
     var unfavoriteText = "unfavorite";
     var favoriteURL = '/api/favorite.json';


### PR DESCRIPTION
## Summary
remove api calls from viewing a location

**Zube Card Referenced** [288](https://zube.io/smartlogic/bchd/c/288)

**Files Modified**
- `app/controllers/locations_controller.rb`: add url instance variable to replace code in api serializer
- `app/models/location.rb`: replace api call with db call, add coordinates method
- `app/views/component/detail/_service_categories.html.haml`, `app/views/component/detail/_service_situations_group.html.haml`: use dot notation to access nested data
- `app/views/component/locations/detail/_body.html.haml`: use url instance variable from controller rather than api serializer method

### Migrations to Run: No

### Tests to Run
- `spec/features/whatver_spec.rb`: Tests the function `hello_world`
