### PR TITLE
287 - Locations Search doesn't use the API

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,5 +1,6 @@
 class LocationsController < ApplicationController
   include Cacheable
+  include PaginationHeaders
 
   def index
     # To enable Google Translation of keywords,
@@ -20,7 +21,39 @@ class LocationsController < ApplicationController
     if params["categories"] and @main_category_selected_id != ""
       params["categories_ids"] = helpers.get_subcategories_ids(params["categories"], @main_category_selected_id)
     end
-    locations = Location.search(params).compact
+
+    search_params = params.dup
+
+    if !params["categories"]
+      search_params["categories"] = params["main_category_id"]
+    else
+      search_params["categories"] = params["categories_ids"]
+    end
+
+
+    set_coordinates
+    locations = LocationsSearch.new(
+      accessibility: search_params[:accessibility],
+      category_ids: search_params[:categories],
+      distance: search_params[:distance],
+      keywords: search_params[:keyword],
+      lat: @lat,
+      long: @lon,
+      org_name: search_params[:org_name],
+      tags: search_params[:tags],
+      zipcode: search_params[:location],
+      page: search_params[:page],
+      per_page: search_params[:per_page],
+      languages: search_params[:languages]
+    ).search.load&.objects
+
+    generate_pagination_headers(locations)
+
+    locations = locations.compact
+
+
+
+
     @search = Search.new(locations, Ohanakapa.last_response, params)
     @keyword = params[:keyword]
     @lat = params[:lat]
@@ -89,6 +122,21 @@ class LocationsController < ApplicationController
 
   def validate_category
     return helpers.main_categories_array.map{|row| row[0] }.include?(params[:main_category])
+  end
+
+  def set_coordinates
+    address = params[:address]
+    if address.present? && address != "Current Location"
+      response = Geocoder.search(params[:address])
+      unless response.empty?
+        coordinates = response.first.data['geometry']['location']
+        @lat = coordinates['lat']
+        @lon = coordinates['lng']
+      end  
+    elsif params[:lat].present? && params[:long]
+      @lat = params[:lat]
+      @lon = params[:long]
+    end
   end
 
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -23,8 +23,8 @@ class LocationsController < ApplicationController
 
     search_params = params.dup
 
-    if !params["categories"]
-      search_params["categories"] = params["main_category_id"]
+    if !params["categories"] and !params[:main_category].empty?
+      search_params["categories"] = [params["main_category_id"]]
     else
       search_params["categories"] = params["categories_ids"]
     end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,6 +1,5 @@
 class LocationsController < ApplicationController
   include Cacheable
-  include PaginationHeaders
 
   def index
     # To enable Google Translation of keywords,
@@ -46,12 +45,6 @@ class LocationsController < ApplicationController
       per_page: search_params[:per_page],
       languages: search_params[:languages]
     ).search.load&.objects
-
-    generate_pagination_headers(locations)
-
-    locations = locations.compact
-
-
 
 
     @search = Search.new(locations, Ohanakapa.last_response, params)

--- a/app/javascript/packs/api-applications-index.js
+++ b/app/javascript/packs/api-applications-index.js
@@ -1,0 +1,1 @@
+// This file exists because webpack wants it

--- a/app/javascript/packs/api-applications-index.js
+++ b/app/javascript/packs/api-applications-index.js
@@ -1,1 +1,0 @@
-// This file exists because webpack wants it

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -228,6 +228,14 @@ class Location < ApplicationRecord
     self.featured_at = Time.current if value == "1"
   end
 
+  # See app/models/concerns/handle_search.rb
+  include HandleSearch
+
+  # Calls the locations/{id} endpoint of the Ohana API.
+  # Fetches a single location by id.
+  #
+  # @param id [String] Location id.
+  # @return [Sawyer::Resource] Hash of location details.
   def self.get(id)
     location = Location.includes(
       :file_uploads,

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -263,12 +263,6 @@ class Location < ApplicationRecord
     generate_pagination_headers(locations)
   end
 
-  def coordinates
-    return [] unless self.longitude.present? && self.latitude.present?
-
-    [self.longitude, self.latitude]
-  end
-
   # Calls the locations/{id} endpoint of the Ohana API.
   # Fetches a single location by id.
   #

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -242,7 +242,31 @@ class Location < ApplicationRecord
     else
       search_params["categories"] = params["categories_ids"]
     end
-    Ohanakapa.search('search', search_params)
+
+    set_coordinates
+
+    locations = LocationsSearch.new(
+      accessibility: search_params[:accessibility],
+      category_ids: search_params[:categories],
+      distance: search_params[:distance],
+      keywords: search_params[:keyword],
+      lat: @lat,
+      long: @lon,
+      org_name: search_params[:org_name],
+      tags: search_params[:tags],
+      zipcode: search_params[:location],
+      page: search_params[:page],
+      per_page: search_params[:per_page],
+      languages: search_params[:languages]
+    ).search.load&.objects
+    
+    generate_pagination_headers(locations)
+  end
+
+  def coordinates
+    return [] unless self.longitude.present? && self.latitude.present?
+
+    [self.longitude, self.latitude]
   end
 
   # Calls the locations/{id} endpoint of the Ohana API.

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -242,25 +242,7 @@ class Location < ApplicationRecord
     else
       search_params["categories"] = params["categories_ids"]
     end
-
-    set_coordinates
-
-    locations = LocationsSearch.new(
-      accessibility: search_params[:accessibility],
-      category_ids: search_params[:categories],
-      distance: search_params[:distance],
-      keywords: search_params[:keyword],
-      lat: @lat,
-      long: @lon,
-      org_name: search_params[:org_name],
-      tags: search_params[:tags],
-      zipcode: search_params[:location],
-      page: search_params[:page],
-      per_page: search_params[:per_page],
-      languages: search_params[:languages]
-    ).search.load&.objects
-    
-    generate_pagination_headers(locations)
+    Ohanakapa.search('search', search_params)
   end
 
   # Calls the locations/{id} endpoint of the Ohana API.

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -228,28 +228,6 @@ class Location < ApplicationRecord
     self.featured_at = Time.current if value == "1"
   end
 
-  # See app/models/concerns/search.rb
-  include HandleSearch
-
-    # Calls the search endpoint of the Ohana API.
-  #
-  # @param params [Hash] Search options.
-  # @return [Array] Array of locations.
-  def self.search(params = {})
-    search_params = params.dup
-    if !params["categories"]
-      search_params["categories"] = params["main_category_id"]
-    else
-      search_params["categories"] = params["categories_ids"]
-    end
-    Ohanakapa.search('search', search_params)
-  end
-
-  # Calls the locations/{id} endpoint of the Ohana API.
-  # Fetches a single location by id.
-  #
-  # @param id [String] Location id.
-  # @return [Sawyer::Resource] Hash of location details.
   def self.get(id)
     location = Location.includes(
       :file_uploads,

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -231,11 +231,6 @@ class Location < ApplicationRecord
   # See app/models/concerns/handle_search.rb
   include HandleSearch
 
-  # Calls the locations/{id} endpoint of the Ohana API.
-  # Fetches a single location by id.
-  #
-  # @param id [String] Location id.
-  # @return [Sawyer::Resource] Hash of location details.
   def self.get(id)
     location = Location.includes(
       :file_uploads,

--- a/app/views/component/locations/results/_header_summary.html.haml
+++ b/app/views/component/locations/results/_header_summary.html.haml
@@ -6,13 +6,13 @@
           %i.fa.fa-chevron-up
           Top
 
-    = paginate search.results
+    = paginate search.locations
 
   .left-column
     %span.static-content><
     %p.search-summary
       %span
-        = page_entries_info search.results, entry_name: 'result'
+        = page_entries_info search.locations, entry_name: 'result'
 
       %span.map-summary.static-content
         = map_summary unless search.map_data.empty?

--- a/app/views/component/locations/results/_list_view.html.haml
+++ b/app/views/component/locations/results/_list_view.html.haml
@@ -41,4 +41,4 @@
                     = render 'component/locations/results/service_wait_table_row', service: service
 
   %footer
-    = paginate search.results
+    = paginate search.locations


### PR DESCRIPTION
## Summary
Location search uses `LocationSearch` directly

**Zube Card Referenced** 287

**Files Modified**
- app/controllers/locations_controller.rb - do the search directly rather than through Ohanakapa
- app/views/component/locations/results/_header_summary.html.haml &&
- app/views/component/locations/results/_list_view.html.haml
                      - since we're not getting back an http response we do the pagination on the locations array directly 

### Migrations to Run: No