### PR TITLE
308: en.date.formats.holiday_schedules_date added to config to fix sentry error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,6 +501,8 @@ en:
       - Saturday
       - Sunday
     closed: 'CLOSED'
+    formats:
+      holiday_schedules_date: '%B %e'
 
   errors:
     api_down: >


### PR DESCRIPTION
## Summary
fix for sentry error:
<img width="595" alt="Screen Shot 2022-03-07 at 2 52 56 PM" src="https://user-images.githubusercontent.com/80838326/157116100-acb9ad72-4a06-41ce-9a6e-5a2ca93cee4b.png">

## NOTE:
this is a fix for the sentry error/ability to display the date in proper format, now the page renders but revealed new error:  holiday hours show up as html on the page. working on fix for that now.

**Zube Card Referenced** [308](https://zube.io/smartlogic/bchd/c/308)

**Files Modified**
- `config/locales/en.yml`: Added en.date.formats.holiday_schedules_date

### Migrations to Run: No

### Tests to Run
- tried to replicate condition for sentry error by running a GET to a location page that had associated holiday hours (locations/example-location). the page had an error before adding holiday_schedules_date, and did not after
