### PR TITLE
Fix for holiday hours view

### DIFF
--- a/app/helpers/schedules_helper.rb
+++ b/app/helpers/schedules_helper.rb
@@ -20,7 +20,6 @@ module SchedulesHelper
     schedules.map { |schedule| holiday_schedule_content_for(schedule) }.
       join(' ').html_safe
   end
-
   private
 
   def valid_weekday_range_schedule?(schedules)
@@ -71,7 +70,7 @@ module SchedulesHelper
   #   or range of weekdays.
   def holiday_schedule_content_for(schedule)
     content_tag :section do
-      holiday_label(schedule.label) +
+      holiday_label(schedule.label).html_safe +
       "#{date_range_for(schedule.start_date, schedule.end_date)}: "\
       "#{holiday_hours(
         schedule.closed, schedule.opens_at, schedule.closes_at


### PR DESCRIPTION
## Summary
After fixing sentry error (card 308), locations with holiday hour were able to render but the hours were displayed as html on the page. Fixed by making sure all strings being concatenated were html safe

**Zube Card Referenced** [308](https://zube.io/smartlogic/bchd/c/308)

**Files Modified**
- `app/helpers/schedules_helper.rb`: modified holiday_schedule_content_for method to make sure all strings being concatenated are html_safe

### Migrations to Run: No

### Tests to Run
- can test functionality on http://sldev.me:8080/locations/example-location (a location that has holiday hours, since some don't)
