### PR TITLE
309: fix flaky tests

### DIFF
--- a/spec/features/admin/services/update_languages_spec.rb
+++ b/spec/features/admin/services/update_languages_spec.rb
@@ -19,12 +19,6 @@ feature 'Update languages' do
     expect(@service.reload.languages).to eq ['French']
   end
 
-  scenario 'with two languages', :js do
-    fill_in(placeholder: I18n.t('admin.services.forms.languages.placeholder'), with: "French\nSpanish\n")
-    click_button I18n.t('admin.buttons.save_changes')
-    expect(@service.reload.languages).to eq %w[French Spanish]
-  end
-
   scenario 'removing a language', :js do
     @service.update!(languages: %w[Arabic French])
     visit '/admin/locations/' + @loc.slug


### PR DESCRIPTION
## Summary
fixes flaky tests as follows:
spec/api/get_location_spec.rb:270 (seems to be passing now every time i test it)
spec/features/admin/services/update_languages_spec.rb:22 (deleted test per instructions, left the previous test for adding one language as-is -- skipped -- for now)

**Zube Card Referenced** [309](https://zube.io/smartlogic/bchd/c/309)

**Files Modified**
- `spec/features/admin/services/create_service_spec.rb`: remove test 22, adding two languages

### Migrations to Run: No
