### PR TITLE
Add support for linux platform, cause of deploy failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,6 +377,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.11.7-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-linux)
+      racc (~> 1.4)
     ohanakapa (1.1.3)
       sawyer (~> 0.8)
     orm_adapter (0.5.0)
@@ -567,6 +569,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   active_data


### PR DESCRIPTION
## Summary
Add platform support to the Gemfile.lock for Linux