### PR TITLE
make tailwind classes work with haml syntax

### DIFF
--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
     './app/javascript/**/*.js',
     './app/views/**/*.{erb,haml,html,slim}'
   ],
+  options: {
+    defaultExtractor: content => content.match(/[^<>"{\.'`\s]*[^<>"{\.'`\s:]/g) || [],
+  },
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## Summary
make multiple tailwind classes work with .haml syntax by adding a regex to the defaultExtractor.

.haml files use .classname1.classname2.classname3 etc syntax for adding classes which doesn't work out of the box with Tailwind. This fixes that. 

**Files Modified**
config/tailwind.config.js