### PR TITLE
planting seeds for admin redesign

### DIFF
--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -10,9 +10,6 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require select2
- *= require select2-bootstrap
- *= require framework_and_overrides
  *= require simplemde.min
  *= require_self
  */

--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -458,3 +458,8 @@ a.boxed-action:active {
   display: none;
 }
 
+.required > label:after {
+  content: ' *';
+  display:inline;
+}
+

--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -10,6 +10,7 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
+ *= require select2
  *= require simplemde.min
  *= require_self
  */
@@ -22,6 +23,9 @@
 
 // creates styles for text in the navbar that is not a link
 .navbar-default {
+  background-color: rgba($blue, .05);
+  width: 100%;
+
   #logo {
     float: left;
     margin-right: 20px;
@@ -51,13 +55,18 @@
   }
 
   .navbar-nav {
-    float: right;
+    padding-bottom: 15px;
+    
+    li {
+      display: inline;
+      margin: 10px;
+    }
 
-    > li > a {
+    li > a {
       font-size: 17px;
       font-weight: 550;
       line-height: 55px;
-      color: rgba($grey, .6);
+      color: #007FAA;
 
       .edit-account {
         font-size: 21px;
@@ -69,6 +78,7 @@
         text-align: center;
         line-height: 2em;
         margin-top: .3em;
+        display: inline-block;
       }
     }
 
@@ -79,7 +89,7 @@
 }
 
 #main .content {
-  padding: 100px 10px 60px;
+  padding: 10px 10px 60px;
 }
 
 .content-box {
@@ -443,5 +453,9 @@ a.boxed-action:active {
 
 .tag_form_buttons_container {
   margin-top: 15px;
+}
+
+.hide {
+  display: none;
 }
 

--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -11,6 +11,8 @@
  * file per style scope.
  *
  *= require select2
+ *= require select2-bootstrap
+ *= require framework_and_overrides
  *= require simplemde.min
  *= require_self
  */
@@ -55,11 +57,8 @@
   }
 
   .navbar-nav {
-    padding-bottom: 15px;
-    
     li {
       display: inline;
-      margin: 10px;
     }
 
     li > a {

--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -8,6 +8,7 @@ $grid-float-breakpoint: 960px;
 
 html {
   font-size: 16px;
+  font-family: 'Lato', sans-serif !important;
 }
 .content {
   font-size: 16px;

--- a/app/assets/stylesheets/framework_and_overrides.css.scss
+++ b/app/assets/stylesheets/framework_and_overrides.css.scss
@@ -6,7 +6,9 @@ $grid-float-breakpoint: 960px;
 @import 'bootstrap';
 @import 'variables';
 
-
+html {
+  font-size: 16px;
+}
 .content {
   font-size: 16px;
   line-height: 1.428;

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -5,6 +5,10 @@ class Admin
 
     include Searchable
 
+    def show
+      @organization = Organization.find(params[:id])
+    end  
+
     def index
       @search_terms = search_params(params)
 

--- a/app/helpers/admin/form_helper.rb
+++ b/app/helpers/admin/form_helper.rb
@@ -113,5 +113,9 @@ class Admin
     def weekday_select_field
       WEEKDAYS.each_with_index.map { |day, i| [day, i + 1] }
     end
+
+    def input_field_classes
+      "form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9"
+    end  
   end
 end

--- a/app/helpers/admin/form_helper.rb
+++ b/app/helpers/admin/form_helper.rb
@@ -9,7 +9,7 @@ class Admin
       link_to(
         name,
         '#',
-        class: 'add-fields btn btn-primary', data: { id: id, fields: fields.gsub('\n', '') }
+        class: 'add-fields text-bchd-dark-teal underline decoration-bchd-teal underline-offset-4', data: { id: id, fields: fields.gsub('\n', '') }
       )
     end
 

--- a/app/views/admin/locations/forms/_phones.html.haml
+++ b/app/views/admin/locations/forms/_phones.html.haml
@@ -1,13 +1,12 @@
-.phones
-  .py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
-    %header
-      %strong
-        Phone Numbers
-      - unless f.object.class == Contact
-        %p.desc.text-sm
-          %em
-            = t('.description')
-    .sm:col-span-2.max-w-lg
-      = f.fields_for :phones do |builder|
-        = render 'admin/locations/forms/phone_fields', f: builder
-      = link_to_add_fields t('admin.buttons.add_phone'), f, :phones
+.phones.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
+  %header
+    %strong
+      Phone Numbers
+    - unless f.object.class == Contact
+      %p.desc.text-sm
+        %em
+          = t('.description')
+  .sm:col-span-2.max-w-lg
+    = f.fields_for :phones do |builder|
+      = render 'admin/locations/forms/phone_fields', f: builder
+    = link_to_add_fields t('admin.buttons.add_phone'), f, :phones

--- a/app/views/admin/locations/forms/_phones.html.haml
+++ b/app/views/admin/locations/forms/_phones.html.haml
@@ -1,12 +1,13 @@
-.inst-box.phones
-  %header
-    %strong
-      Phone Numbers
-    - unless f.object.class == Contact
-      %p.desc
-        %em
-          = t('.description')
-
-  = f.fields_for :phones do |builder|
-    = render 'admin/locations/forms/phone_fields', f: builder
-  = link_to_add_fields t('admin.buttons.add_phone'), f, :phones
+.phones
+  .py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
+    %header
+      %strong
+        Phone Numbers
+      - unless f.object.class == Contact
+        %p.desc.text-sm
+          %em
+            = t('.description')
+    .sm:col-span-2.max-w-lg
+      = f.fields_for :phones do |builder|
+        = render 'admin/locations/forms/phone_fields', f: builder
+      = link_to_add_fields t('admin.buttons.add_phone'), f, :phones

--- a/app/views/admin/organizations/forms/_accreditations.html.haml
+++ b/app/views/admin/organizations/forms/_accreditations.html.haml
@@ -1,9 +1,9 @@
-.inst-box
+.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
   %header
     %strong
       = f.label :accreditations
     %p.desc
       = t('.description')
 
-  = field_set_tag do
-    = f.select :accreditations, organization.accreditations, {}, multiple: true, class: 'form-control', data: { placeholder: t('.placeholder') }
+  .sm:col-span-2.max-w-lg
+    = f.select :accreditations, organization.accreditations, {}, multiple: true, class: 'form-control rounded-md border-gray-300! focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9', data: { placeholder: t('.placeholder') }

--- a/app/views/admin/organizations/forms/_description.html.haml
+++ b/app/views/admin/organizations/forms/_description.html.haml
@@ -1,8 +1,8 @@
-.inst-box
-  %header
+.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
+  %header.required
     = f.label :description
-    %span.desc
+    .desc
       = t('.description')
 
-  = field_set_tag do
-    = f.text_area :description, required: false, class: 'form-control', rows: 10
+  .sm:col-span-2.max-w-lg
+    = f.text_area :description, required: false, class: 'form-control text-sm', rows: 6

--- a/app/views/admin/organizations/forms/_fields.html.haml
+++ b/app/views/admin/organizations/forms/_fields.html.haml
@@ -4,19 +4,20 @@
     %ul
       - organization.errors.full_messages.each do |msg|
         %li= msg
-
+%h2.text-xl.underline.decoration-bchd-teal.underline-offset-4 General Information
 = render 'admin/shared/forms/name', f: f
 = render 'admin/shared/forms/alternate_name', f: f
 = render 'admin/organizations/forms/accreditations', f: f, organization: organization
 -# = render 'admin/organizations/forms/date_incorporated', f: f
 = render 'admin/organizations/forms/description', f: f
-= render 'admin/shared/forms/email', f: f
+= render 'admin/organizations/forms/legal_status', f: f
+= render 'admin/organizations/forms/tax_status', f: f
 -# = render 'admin/shared/forms/funding_sources', f: f
 = render 'admin/shared/forms/tags', f: f
-= render 'admin/organizations/forms/legal_status', f: f
-= render 'admin/locations/index', organization: organization
+-# = render 'admin/locations/index', organization: organization
 -# = render 'admin/organizations/forms/licenses', f: f, organization: organization
 -# = render 'admin/organizations/forms/tax_id', f: f
-= render 'admin/organizations/forms/tax_status', f: f
+%h2.text-xl.underline.decoration-bchd-teal.underline-offset-4.mt-6 Contact Information
 = render 'admin/shared/forms/website', f: f
+= render 'admin/shared/forms/email', f: f
 = render 'admin/locations/forms/phones', f: f

--- a/app/views/admin/organizations/forms/_legal_status.html.haml
+++ b/app/views/admin/organizations/forms/_legal_status.html.haml
@@ -5,4 +5,4 @@
       = t('.description')
 
   .sm:col-span-2.max-w-lg
-    = f.text_field :legal_status, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'
+    = f.text_field :legal_status, required: false, maxlength: 255, class: input_field_classes

--- a/app/views/admin/organizations/forms/_legal_status.html.haml
+++ b/app/views/admin/organizations/forms/_legal_status.html.haml
@@ -1,10 +1,8 @@
-.inst-box
+.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
   %header
     = f.label :legal_status
-    %span.desc
+    .desc
       = t('.description')
 
-  = field_set_tag do
-    .row
-      .col-sm-6
-        = f.text_field :legal_status, required: false, maxlength: 255, class: 'form-control'
+  .sm:col-span-2.max-w-lg
+    = f.text_field :legal_status, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'

--- a/app/views/admin/organizations/forms/_new_organization_form.html.haml
+++ b/app/views/admin/organizations/forms/_new_organization_form.html.haml
@@ -1,3 +1,3 @@
 = render 'admin/organizations/forms/fields', f: f, organization: organization
 
-= f.submit t('admin.buttons.create_organization'), class: 'btn btn-primary btn-lg', data: { disable_with: 'Please wait...' }
+= f.submit t('admin.buttons.create_organization'), class: 'btn btn-primary btn-lg float-right bg-bchd-dark-teal mt-4', data: { disable_with: 'Please wait...' }

--- a/app/views/admin/organizations/forms/_tax_status.html.haml
+++ b/app/views/admin/organizations/forms/_tax_status.html.haml
@@ -1,10 +1,8 @@
-.inst-box
+.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
   %header
     = f.label :tax_status
-    %span.desc
+    .desc
       = t('.description')
 
-  = field_set_tag do
-    .row
-      .col-sm-6
-        = f.text_field :tax_status, required: false, maxlength: 255, class: 'form-control'
+  .sm:col-span-2.max-w-lg
+    = f.text_field :tax_status, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'

--- a/app/views/admin/organizations/forms/_tax_status.html.haml
+++ b/app/views/admin/organizations/forms/_tax_status.html.haml
@@ -5,4 +5,4 @@
       = t('.description')
 
   .sm:col-span-2.max-w-lg
-    = f.text_field :tax_status, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'
+    = f.text_field :tax_status, required: false, maxlength: 255, class: input_field_classes

--- a/app/views/admin/organizations/new.html.haml
+++ b/app/views/admin/organizations/new.html.haml
@@ -1,5 +1,5 @@
-.content-box
-  %h1 Create a new organization
+
+%h1.text-3xl.mb-4 Create a new organization
 
 = form_for [:admin, @organization], url: admin_organizations_path, html: { method: :post, class: 'edit-entry' } do |f|
   = render 'admin/organizations/forms/new_organization_form', f: f, organization: @organization

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -1,0 +1,88 @@
+<div>
+  <h3 class="text-lg font-medium leading-6 text-gray-900">Applicant Information</h3>
+  <p class="mt-1 max-w-2xl text-sm text-gray-500">Personal details and application.</p>
+</div>
+<div class="mt-5 border-t border-gray-200">
+  <dl class="divide-y divide-gray-200">
+    <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5">
+      <dt class="text-sm font-medium text-gray-500">Full name</dt>
+      <dd class="mt-1 flex text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+        <span class="flex-grow">Margot Foster</span>
+        <span class="ml-4 flex-shrink-0">
+          <button type="button" class="rounded-md bg-white font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Update</button>
+        </span>
+      </dd>
+    </div>
+    <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5">
+      <dt class="text-sm font-medium text-gray-500">Application for</dt>
+      <dd class="mt-1 flex text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+        <span class="flex-grow">Backend Developer</span>
+        <span class="ml-4 flex-shrink-0">
+          <button type="button" class="rounded-md bg-white font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Update</button>
+        </span>
+      </dd>
+    </div>
+    <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5">
+      <dt class="text-sm font-medium text-gray-500">Email address</dt>
+      <dd class="mt-1 flex text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+        <span class="flex-grow">margotfoster@example.com</span>
+        <span class="ml-4 flex-shrink-0">
+          <button type="button" class="rounded-md bg-white font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Update</button>
+        </span>
+      </dd>
+    </div>
+    <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5">
+      <dt class="text-sm font-medium text-gray-500">Salary expectation</dt>
+      <dd class="mt-1 flex text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+        <span class="flex-grow">$120,000</span>
+        <span class="ml-4 flex-shrink-0">
+          <button type="button" class="rounded-md bg-white font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Update</button>
+        </span>
+      </dd>
+    </div>
+    <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5">
+      <dt class="text-sm font-medium text-gray-500">About</dt>
+      <dd class="mt-1 flex text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+        <span class="flex-grow">Fugiat ipsum ipsum deserunt culpa aute sint do nostrud anim incididunt cillum culpa consequat. Excepteur qui ipsum aliquip consequat sint. Sit id mollit nulla mollit nostrud in ea officia proident. Irure nostrud pariatur mollit ad adipisicing reprehenderit deserunt qui eu.</span>
+        <span class="ml-4 flex-shrink-0">
+          <button type="button" class="rounded-md bg-white font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Update</button>
+        </span>
+      </dd>
+    </div>
+    <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5">
+      <dt class="text-sm font-medium text-gray-500">Attachments</dt>
+      <dd class="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+        <ul role="list" class="divide-y divide-gray-200 rounded-md border border-gray-200">
+          <li class="flex items-center justify-between py-3 pl-3 pr-4 text-sm">
+            <div class="flex w-0 flex-1 items-center">
+              <!-- Heroicon name: mini/paper-clip -->
+              <svg class="h-5 w-5 flex-shrink-0 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M15.621 4.379a3 3 0 00-4.242 0l-7 7a3 3 0 004.241 4.243h.001l.497-.5a.75.75 0 011.064 1.057l-.498.501-.002.002a4.5 4.5 0 01-6.364-6.364l7-7a4.5 4.5 0 016.368 6.36l-3.455 3.553A2.625 2.625 0 119.52 9.52l3.45-3.451a.75.75 0 111.061 1.06l-3.45 3.451a1.125 1.125 0 001.587 1.595l3.454-3.553a3 3 0 000-4.242z" clip-rule="evenodd" />
+              </svg>
+              <span class="ml-2 w-0 flex-1 truncate">resume_back_end_developer.pdf</span>
+            </div>
+            <div class="ml-4 flex flex-shrink-0 space-x-4">
+              <button type="button" class="rounded-md bg-white font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Update</button>
+              <span class="text-gray-300" aria-hidden="true">|</span>
+              <button type="button" class="rounded-md bg-white font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Remove</button>
+            </div>
+          </li>
+          <li class="flex items-center justify-between py-3 pl-3 pr-4 text-sm">
+            <div class="flex w-0 flex-1 items-center">
+              <!-- Heroicon name: mini/paper-clip -->
+              <svg class="h-5 w-5 flex-shrink-0 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M15.621 4.379a3 3 0 00-4.242 0l-7 7a3 3 0 004.241 4.243h.001l.497-.5a.75.75 0 011.064 1.057l-.498.501-.002.002a4.5 4.5 0 01-6.364-6.364l7-7a4.5 4.5 0 016.368 6.36l-3.455 3.553A2.625 2.625 0 119.52 9.52l3.45-3.451a.75.75 0 111.061 1.06l-3.45 3.451a1.125 1.125 0 001.587 1.595l3.454-3.553a3 3 0 000-4.242z" clip-rule="evenodd" />
+              </svg>
+              <span class="ml-2 w-0 flex-1 truncate">coverletter_back_end_developer.pdf</span>
+            </div>
+            <div class="ml-4 flex flex-shrink-0 space-x-4">
+              <button type="button" class="rounded-md bg-white font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Update</button>
+              <span class="text-gray-300" aria-hidden="true">|</span>
+              <button type="button" class="rounded-md bg-white font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Remove</button>
+            </div>
+          </li>
+        </ul>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/app/views/admin/shared/_navigation.html.haml
+++ b/app/views/admin/shared/_navigation.html.haml
@@ -1,8 +1,8 @@
-%header.navbar.navbar-default.navbar-fixed-top
-  .container
+%header
+  .navbar-default.navbar
     .navbar-header
       #logo
-        %a{ href: '/', target: '_self' }
+        %a{ href: '/admin', target: '_self' }
           %img{ src: asset_path(SETTINGS[:site_logo]), alt: "#{t('titles.brand')} Logo" }
       = button_tag type: 'button', class: 'navbar-toggle', data: { toggle: 'collapse', target: '.navbar-collapse' } do
         %span.sr-only
@@ -10,8 +10,7 @@
         %span.icon-bar
         %span.icon-bar
         %span.icon-bar
-      = link_to t('titles.admin'),
-                admin_dashboard_url, class: 'navbar-brand'
+
     %nav.collapse.navbar-collapse
       %ul.nav.navbar-nav
         = render 'admin/shared/navigation_links'

--- a/app/views/admin/shared/_navigation.html.haml
+++ b/app/views/admin/shared/_navigation.html.haml
@@ -10,12 +10,14 @@
         %span.icon-bar
         %span.icon-bar
         %span.icon-bar
-
+      = link_to t('titles.admin'),
+                admin_dashboard_url, class: 'navbar-brand hide'
     %nav.collapse.navbar-collapse
       %ul.nav.navbar-nav
         = render 'admin/shared/navigation_links'
       %ul.nav.navbar-nav.navbar-right
-        %li
-          = link_to t('navigation.sign_out'), destroy_admin_session_path, method: 'delete'
-        %li
-          = link_to tag.div("#{current_admin.name[0].upcase}", class: 'edit-account'), edit_admin_registration_path  
+        - if admin_signed_in?
+          %li
+            = link_to t('navigation.sign_out'), destroy_admin_session_path, method: 'delete'
+          %li
+            = link_to tag.div("#{current_admin.name[0].upcase}", class: 'edit-account'), edit_admin_registration_path  

--- a/app/views/admin/shared/_navigation.html.haml
+++ b/app/views/admin/shared/_navigation.html.haml
@@ -14,3 +14,8 @@
     %nav.collapse.navbar-collapse
       %ul.nav.navbar-nav
         = render 'admin/shared/navigation_links'
+      %ul.nav.navbar-nav.navbar-right
+        %li
+          = link_to t('navigation.sign_out'), destroy_admin_session_path, method: 'delete'
+        %li
+          = link_to tag.div("#{current_admin.name[0].upcase}", class: 'edit-account'), edit_admin_registration_path  

--- a/app/views/admin/shared/_navigation_links.html.haml
+++ b/app/views/admin/shared/_navigation_links.html.haml
@@ -21,8 +21,3 @@
       = link_to "Analytics", admin_analytics_path
     %li
       = link_to "Tags", admin_tags_path
-  .float-right
-    %li
-      = link_to t('navigation.sign_out'), destroy_admin_session_path, method: 'delete'
-    %li
-      = link_to tag.div("#{current_admin.name[0].upcase}", class: 'edit-account'), edit_admin_registration_path

--- a/app/views/admin/shared/_navigation_links.html.haml
+++ b/app/views/admin/shared/_navigation_links.html.haml
@@ -1,5 +1,7 @@
 - if admin_signed_in?
   %li
+    = link_to t('admin.buttons.dashboard'), admin_dashboard_path
+  %li
     = link_to t('admin.buttons.organizations'), admin_organizations_path
   %li
     = link_to t('admin.buttons.locations'), admin_locations_path
@@ -19,8 +21,8 @@
       = link_to "Analytics", admin_analytics_path
     %li
       = link_to "Tags", admin_tags_path
-
-  %li
-    = link_to t('navigation.sign_out'), destroy_admin_session_path, method: 'delete'
-  %li
-    = link_to tag.div("#{current_admin.name[0].upcase}", class: 'edit-account'), edit_admin_registration_path
+  .float-right
+    %li
+      = link_to t('navigation.sign_out'), destroy_admin_session_path, method: 'delete'
+    %li
+      = link_to tag.div("#{current_admin.name[0].upcase}", class: 'edit-account'), edit_admin_registration_path

--- a/app/views/admin/shared/forms/_alternate_name.html.haml
+++ b/app/views/admin/shared/forms/_alternate_name.html.haml
@@ -5,4 +5,4 @@
       = t('.description', type: f.object.model_name.human.downcase)
 
   .sm:col-span-2.max-w-lg
-    = f.text_field :alternate_name, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'
+    = f.text_field :alternate_name, required: false, maxlength: 255, class: input_field_classes

--- a/app/views/admin/shared/forms/_alternate_name.html.haml
+++ b/app/views/admin/shared/forms/_alternate_name.html.haml
@@ -1,10 +1,8 @@
-.inst-box
+.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
   %header
     = f.label :alternate_name
     %p.desc
       = t('.description', type: f.object.model_name.human.downcase)
 
-  = field_set_tag do
-    .row
-      .col-sm-6
-        = f.text_field :alternate_name, required: false, maxlength: 255, class: 'form-control'
+  .sm:col-span-2.max-w-lg
+    = f.text_field :alternate_name, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'

--- a/app/views/admin/shared/forms/_email.html.haml
+++ b/app/views/admin/shared/forms/_email.html.haml
@@ -1,10 +1,8 @@
-.inst-box
+.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
   %header
-    = f.label :contact_info, 'Contact Info'
-    %p.desc
-      = t('.description', type: f.object.model_name.human.downcase)
+    = f.label :contact_info, 'Contact Email'
+    -#%p.desc
+    -#  = t('.description', type: f.object.model_name.human.downcase)
 
-  = field_set_tag do
-    .row
-      .col-sm-6
-        = f.email_field :email, required: false, maxlength: 255, class: 'form-control'
+  .sm:col-span-2.max-w-lg
+    = f.email_field :email, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'

--- a/app/views/admin/shared/forms/_email.html.haml
+++ b/app/views/admin/shared/forms/_email.html.haml
@@ -5,4 +5,4 @@
     -#  = t('.description', type: f.object.model_name.human.downcase)
 
   .sm:col-span-2.max-w-lg
-    = f.email_field :email, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'
+    = f.email_field :email, required: false, maxlength: 255, class: input_field_classes

--- a/app/views/admin/shared/forms/_name.html.haml
+++ b/app/views/admin/shared/forms/_name.html.haml
@@ -2,4 +2,4 @@
   %header.required
     = f.label :name
   .sm:col-span-2.max-w-lg
-    = f.text_field :name, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'
+    = f.text_field :name, required: false, maxlength: 255, class: input_field_classes

--- a/app/views/admin/shared/forms/_name.html.haml
+++ b/app/views/admin/shared/forms/_name.html.haml
@@ -1,7 +1,5 @@
-.inst-box
-  %header
+.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
+  %header.required
     = f.label :name
-  = field_set_tag do
-    .row
-      .col-sm-6
-        = f.text_field :name, required: false, maxlength: 255, class: 'form-control'
+  .sm:col-span-2.max-w-lg
+    = f.text_field :name, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'

--- a/app/views/admin/shared/forms/_tags.html.haml
+++ b/app/views/admin/shared/forms/_tags.html.haml
@@ -1,12 +1,12 @@
-.inst-box.funding_sources
+.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
   %header
     %strong
       = f.label :tags
 
-  = field_set_tag do
+  .sm:col-span-2.max-w-lg
     = select_tag "#{f.object.model_name.singular}[tag_list][]",
       options_for_select(Tag.pluck(:name), f.object.tags.pluck(:name)),
-      id: 'taggable', class: 'form-control', multiple: true
+      id: 'taggable', class: 'form-control rounded-md border-gray-300! focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9', multiple: true
 
 :javascript
   var tags = #{raw (Tag.pluck(:name)).to_json}

--- a/app/views/admin/shared/forms/_website.html.haml
+++ b/app/views/admin/shared/forms/_website.html.haml
@@ -1,7 +1,5 @@
-.inst-box
+.py-4.sm:grid.sm:grid-cols-3.sm:gap-4.sm:py-5.border-b.border-gray-300
   %header
     = f.label :website
-  = field_set_tag do
-    .row
-      .col-sm-6
-        = f.url_field :website, required: false, maxlength: 255, class: 'form-control'
+  .sm:col-span-2.max-w-lg
+    = f.url_field :website, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'

--- a/app/views/admin/shared/forms/_website.html.haml
+++ b/app/views/admin/shared/forms/_website.html.haml
@@ -2,4 +2,4 @@
   %header
     = f.label :website
   .sm:col-span-2.max-w-lg
-    = f.url_field :website, required: false, maxlength: 255, class: 'form-control rounded-md border-gray-400 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm h-9'
+    = f.url_field :website, required: false, maxlength: 255, class: input_field_classes

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -9,7 +9,6 @@
     = favicon_link_tag 'CHARMcareCFavicon.png', rel: 'icon', type: 'image/png'
     = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Lato:400,700'
     = stylesheet_link_tag 'admin/application', media: 'all'
-    = stylesheet_pack_tag 'application'
     = stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload"
     = csrf_meta_tags
     = yield(:head)
@@ -19,7 +18,7 @@
     = render 'shared/environment_variables'
     #main{ role: 'main' }
       .content
-        .container
+        .container.mx-auto
           .row
             = render 'shared/messages'
             = yield

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -10,6 +10,7 @@
     = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Lato:400,700'
     = stylesheet_link_tag 'admin/application', media: 'all'
     = stylesheet_pack_tag 'application'
+    = stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload"
     = csrf_meta_tags
     = yield(:head)
   %body{ class: "#{controller_name} #{action_name}" }

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -7,12 +7,12 @@
     %title= content_for?(:title) ? yield(:title) : t('titles.admin', brand: t('titles.brand'))
     %meta{ content: content_for?(:description) ? yield(:description) : "Admin Interface for #{t('titles.brand')}", name: 'description' }
     = favicon_link_tag 'CHARMcareCFavicon.png', rel: 'icon', type: 'image/png'
-    = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Lato:400,700'
+    = stylesheet_link_tag 'http://fonts.googleapis.com/css?family=Lato:400,700', rel: 'stylesheet', type: 'text/css'
     = stylesheet_link_tag 'admin/application', media: 'all'
     = stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload"
     = csrf_meta_tags
     = yield(:head)
-  %body{ class: "#{controller_name} #{action_name}" }
+  %body{ class: "#{controller_name} #{action_name} font-sans" }
     = render 'admin/shared/navigation'
     = render 'shared/alert'
     = render 'shared/environment_variables'

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -7,7 +7,7 @@
     %title= content_for?(:title) ? yield(:title) : t('titles.admin', brand: t('titles.brand'))
     %meta{ content: content_for?(:description) ? yield(:description) : "Admin Interface for #{t('titles.brand')}", name: 'description' }
     = favicon_link_tag 'CHARMcareCFavicon.png', rel: 'icon', type: 'image/png'
-    = stylesheet_link_tag 'http://fonts.googleapis.com/css?family=Lato:400,700', rel: 'stylesheet', type: 'text/css'
+    = stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Lato:400,700', rel: 'stylesheet', type: 'text/css'
     = stylesheet_link_tag 'admin/application', media: 'all'
     = stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload"
     = csrf_meta_tags

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -14,7 +14,6 @@
     = yield(:head)
   %body{ class: "#{controller_name} #{action_name} font-sans" }
     = render 'admin/shared/navigation'
-    = render 'shared/alert'
     = render 'shared/environment_variables'
     #main{ role: 'main' }
       .content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,8 @@ Rails.application.routes.draw do
       resources :contacts, except: %i[show index]
     end
 
-    resources :organizations do
-      resources :contacts, except: %i[index], controller: "organization_contacts"
+    resources :organizations, except: :show do
+      resources :contacts, except: %i[show index], controller: "organization_contacts"
     end
     resources :programs, except: :show
     resources :services, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,8 @@ Rails.application.routes.draw do
       resources :contacts, except: %i[show index]
     end
 
-    resources :organizations, except: :show do
-      resources :contacts, except: %i[show index], controller: "organization_contacts"
+    resources :organizations do
+      resources :contacts, except: %i[index], controller: "organization_contacts"
     end
     resources :programs, except: :show
     resources :services, only: :index

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -16,6 +16,7 @@ module.exports = {
       },
       colors: {
         'bchd-teal': '#007FAA',
+        'bchd-dark-teal': '#005875'
       },
     },
   },

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -12,7 +12,10 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+        sans: ['Lato', ...defaultTheme.fontFamily.sans],
+      },
+      colors: {
+        'bchd-teal': '#007FAA',
       },
     },
   },


### PR DESCRIPTION
## Summary
This is an example implementation of the Create an Organization page using the new design scheme and Tailwind CSS. I'm more or less happy with the approach and think this would be a sane way to continue with the rest of the admin pages.

Originally I wanted to remove bootstrap from the admin side entirely. This seemed to make sense because who wants two CSS frameworks? I removed bootstrap and re-styled a few of the obviously broken things. Then became apparent the big downside to this: things like nav, modals, and multi-select, whose interactivity and dynamic styles we get for free using bootstrap, would have to be re-implemented using tailwind. Tailwind doesn't have a similar out-of-the-box JS strategy so we would have to write our own custom JS for those features. Not the end of the world, but not ideal, and would add lots of implementation time re-inventing the wheel. 

Thus, I put bootstrap back in and made a few tweaks so that it would play nicely with Tailwind while still giving us that interactive JS for free. There are a few examples I could find online of people using bootstrap and tailwind together like this so maybe it's not as insane as I thought. 

The other big part of this was figuring out how much of the existing .haml files to use. I ended up putting tailwind utility classes into the pre-existing template partials, many of which already reside in a shared folder. This "re-use as much as possible" approach makes sense to me for productivity reasons but if others have ideas for how to structure the templates in a different way I'm super open to exploring that. 

This PR also styles the admin navbar to match the redesign and scaffolds a "show" page for organizations. 



<img width="1428" alt="Screen Shot 2022-11-16 at 5 27 33 PM" src="https://user-images.githubusercontent.com/51140224/202308116-bc9b2348-eba3-43a3-8984-efaf346f338d.png">


<img width="1427" alt="Screen Shot 2022-11-16 at 5 29 38 PM" src="https://user-images.githubusercontent.com/51140224/202308415-2c56825a-a1e9-4d3b-adea-cd71ae93fccf.png">



