### PR TITLE
update public user styling

### DIFF
--- a/app/assets/stylesheets/components/_devise.scss
+++ b/app/assets/stylesheets/components/_devise.scss
@@ -13,12 +13,12 @@
   label {
     font-size: 0.9em;
   }
+
   form {
-    text-align: left;
-    display: inline;
+    display: inline-block;
   }
   .form {
-    margin: 0 auto;
+    margin: 10 auto;
     max-width: 350px;
   }
   .instructions {
@@ -30,7 +30,7 @@
   h2 {
     font-size: 1.5em;
     color: $purple;
-    margin-bottom: 1.5em;
+    margin-top: -1em;
   }
 
   a {
@@ -51,10 +51,10 @@
   }
 
   .button {
-    background-color: $purple-t;
+    background-image: linear-gradient(to right, #007faa, #835eb1);
     border: none;
     border: 1px solid rgba(0, 0, 0, 0);
-    color: $blue;
+    color: $white;
     display: inline-block;
     padding: .5em;
     margin: .2em;
@@ -80,8 +80,9 @@
     }
   }
 
-  .field {
+  .form-group {
     margin-bottom: 15px;
+    text-align: left;
 
     input[type='text'], input[type='email'], input[type='password'] {
       font-size: 1.1em;
@@ -120,6 +121,7 @@
   table .actions .button {
     margin-top: 10px;
     margin-bottom: 10px;
+    text-align: center;
   }
   .nav-buttons {
     width: 100%;

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,12 +1,12 @@
-.authform
+.authform.devise
+  = content_tag(:span, nil, class: 'fa fa-key fa-3x', style: "display: block")  
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, role: 'form' }) do |f|
-    %h3 Forgot your password?
-    %p
-      Enter the email you signed up with, and we'll send you password reset instructions.
+    %h2 Forgot your password?
     = render 'devise/shared/error_messages', resource: resource
     .form-group
       = f.label :email
+      %br
       = f.email_field :email, autofocus: true, class: 'form-control'
     = f.submit t('buttons.send_reset_password_instructions'), class: 'button center'
-    %br
+  %br
   = render 'devise/shared/links'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,6 +1,7 @@
-.authform
-  = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { role: 'form' }) do |f|
-    %h3 Sign up
+.authform.devise
+  = content_tag(:span, nil, class: 'fa fa-users fa-3x', style: "display: block")  
+  = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { role: 'form', class: 'form' }) do |f|
+    %h2 Sign up
     = render 'devise/shared/error_messages', resource: resource
     .form-group
       = f.label :name
@@ -15,5 +16,5 @@
       = f.label :password_confirmation
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control'
     = f.submit t('navigation.sign_up'), class: 'button right'
-    %br
+  %br
   = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,22 +1,27 @@
-.authform
+.authform.devise
   - if request.host == 'ohana-api-demo.herokuapp.com' && resource.is_a?(Admin)
     To try out the admin interface, sign in with one of these
     #{link_to 'three demo emails and passwords', 'https://github.com/codeforamerica/ohana-api/blob/master/db/seeds.rb#L24-43'}.
 
-  = form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: 'form' }) do |f|
-    %h3
-      = t('navigation.sign_in')
+  = content_tag(:span, nil, class: 'fa fa-key fa-3x', style: "display: block")  
+
+  = form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: 'form', class: 'form' }) do |f|
+    %h2
+      Login
     .form-group
       = f.label :email
-      = f.email_field :email, autofocus: true, class: 'form-control'
+      %br
+      = f.email_field :email, autofocus: true, class: ''
     .form-group
       = f.label :password
-      = f.password_field :password, autocomplete: 'off', class: 'form-control'
+      %br
+      = f.password_field :password, autocomplete: 'off', class: ''
 
     .form-group
       = f.check_box :remember_me
       = f.label :remember_me
 
-    = f.submit t('navigation.sign_in'), class: 'button'
+    = f.submit "Let's go!", class: 'button'
 
+  %br  
   = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -17,7 +17,10 @@
       = f.check_box :remember_me
       = f.label :remember_me
 
-    = f.submit "Let's go!", class: 'button'
+    - if resource.class.name == User.name
+      = f.submit "Let's go!", class: 'button'
+    - else
+      = f.submit I18n.t('navigation.sign_in'), class: 'button'
 
   %br
   = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,21 +1,17 @@
 .authform.devise
-  - if request.host == 'ohana-api-demo.herokuapp.com' && resource.is_a?(Admin)
-    To try out the admin interface, sign in with one of these
-    #{link_to 'three demo emails and passwords', 'https://github.com/codeforamerica/ohana-api/blob/master/db/seeds.rb#L24-43'}.
-
-  = content_tag(:span, nil, class: 'fa fa-key fa-3x', style: "display: block")  
+  - if resource.class.name == User.name
+    = content_tag(:span, nil, class: 'fa fa-key fa-3x', style: "display: block")
 
   = form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: 'form', class: 'form' }) do |f|
-    %h2
-      Login
+    %h2 Login
     .form-group
       = f.label :email
       %br
-      = f.email_field :email, autofocus: true, class: ''
+      = f.email_field :email, autofocus: true, class: 'form-control'
     .form-group
       = f.label :password
       %br
-      = f.password_field :password, autocomplete: 'off', class: ''
+      = f.password_field :password, autocomplete: 'off', class: 'form-control'
 
     .form-group
       = f.check_box :remember_me
@@ -23,5 +19,5 @@
 
     = f.submit "Let's go!", class: 'button'
 
-  %br  
+  %br
   = render 'devise/shared/links'

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -7,9 +7,6 @@
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
   = link_to t('navigation.forgot_your_password'), new_password_path(resource_name)
   %br/
-- if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to t('navigation.no_confirmation_instructions'), new_confirmation_path(resource_name)
-  %br/
 - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
   = link_to t('navigation.no_unlock_instructions'), new_unlock_path(resource_name)
   %br/


### PR DESCRIPTION
## Summary
updates the public user login pages to match old styling

**Zube Card Referenced** 
https://zube.io/smartlogic/bchd/c/350

<img width="533" alt="Screen Shot 2023-07-24 at 11 47 20 AM" src="https://github.com/bchd/bahc-ohana-api/assets/51140224/33838e7a-b025-48c2-9f00-cdd8ba993c4e">

<img width="530" alt="Screen Shot 2023-07-24 at 11 47 40 AM" src="https://github.com/bchd/bahc-ohana-api/assets/51140224/b0fb8d7f-7e73-4950-996b-58cb4c80272d">

<img width="465" alt="Screen Shot 2023-07-24 at 11 48 02 AM" src="https://github.com/bchd/bahc-ohana-api/assets/51140224/9d888612-8798-46eb-8095-735a5e92cace">
