### PR TITLE
[BCHDCC-28] - "Back" button on results page disables CSS

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -101,7 +101,10 @@ class LocationsController < ApplicationController
     end
 
     # @keywords = @location.services.map { |s| s[:keywords] }.flatten.compact.uniq
-    @categories = @location.services.map { |s| s[:categories] }.flatten.compact.uniq
+    @categories = @location.services.map { |s| s[:categories] }.flatten.compact.uniq 
+
+    request.query_parameters["layout"] = true
+    @query_parameters = request.query_parameters
     @url = request.url
   end
 

--- a/app/views/component/locations/detail/_header_summary.html.haml
+++ b/app/views/component/locations/detail/_header_summary.html.haml
@@ -1,7 +1,7 @@
 %div.content-header
   %span.utility-links
     %span
-      %a.button-utility.button-back{ href: "#{locations_url(request.query_parameters)}##{location.id}", target: '_self' }
+      %a.button-utility.button-back{ href: "#{locations_url(@query_parameters)}##{location.id}", target: '_self' }
         %i.fa.fa-arrow-left
         Back
     %span.header-right><


### PR DESCRIPTION
## Summary
When performing a search by using the left search menu, visiting any of the resource details and clicking on the "back" link on the top left page, the CSS gets disabled 

**ClickUp Ticket Reference**
[BCHDCC-28](https://app.clickup.com/t/9006094761/BCHDCC-28) - "Back" button on results page disables CSS

**File Addition(s)** 
No file addition

**Libraries Added**
No libraries added

### Migrations to Run: No

### Tests to Run
No test added or modified

### TODO
- [ ] Add UI Tests for Service Areas
- [ ] Possibly add model validation for areas
