### PR TITLE
BCHDCC-26, BCHDCC-27, BCHDCC-32, BCHDCC-34 - Pre-Accessibility Fixes

### DIFF
--- a/app/assets/stylesheets/flagging.scss
+++ b/app/assets/stylesheets/flagging.scss
@@ -1,6 +1,7 @@
 input.report-input-checkbox {
   width: 3% !important;
   float: left;
+  margin-right: 5px;
 }
 
 label.report-label {

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -11,7 +11,7 @@ class AdminMailer < ActionMailer::Base
 
   def portal_for(resource)
     return t('titles.admin', brand: t('titles.brand')) if resource.is_a?(Admin)
-    return t('titles.developer', brand: t('titles.brand')) if resource.is_a?(User)
+    return t('titles.brand', brand: t('titles.brand')) if resource.is_a?(User)
   end
 
   def sign_in_url_for(resource)

--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -176,7 +176,7 @@
     var locationUrl = "{@url}";
     var favoriteText = "favorite";
     var unfavoriteText = "unfavorite";
-    var favoriteURL = '/api/favorite.json';
+    var favoriteURL = '/favorite.json';
     var favoriteToggle = $('.favorite-toggle');
 
     $('.favorite-toggle').on('click', function(e){
@@ -203,10 +203,6 @@
             }
           },
           success: function(data){
-            console.log('data')
-            console.log(data)
-            // if success
-            // change button to "favorite"
             favoriteButton();
           }
         });

--- a/app/views/component/search/_language.html.haml
+++ b/app/views/component/search/_language.html.haml
@@ -1,5 +1,5 @@
 = field_set_tag nil, id: 'language-filter', class: 'input-search-filter input-search-filter-option' do
-  = label_tag :languages, 'By Langauge', style: "font-size: 16px;"
+  = label_tag :languages, 'By Language', style: "font-size: 16px;"
   %hr
   = select_tag :languages, options_for_select(@languages, @selected_language), include_blank: 'All', class: "category-search-select-left-menu"
 

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,8 +1,4 @@
 %p Hi #{@resource.name},
-%p Thanks for signing up for a developer account on #{t('titles.brand')}!
+%p Thanks for signing up for an account on #{t('titles.brand')}!
 %p You can confirm your account email through the link below:
 %p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)
-%p
-  After you've confirmed your account, check out the
-  = link_to 'documentation', 'http://codeforamerica.github.io/ohana-api-docs/'
-  to get started.

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -13,7 +13,7 @@
         = resource.email
     - if devise_mapping.confirmable? && resource.pending_reconfirmation?
       %span.help-block
-        You recently updated your email to '#{resource.unconfirmed_email}', but we're still waiting for you to confirm it. Please look for an email from us with the subject 'Confirmation instructions'.
+        You recently updated your email to '#{resource.unconfirmed_email}', but we're still waiting for you to confirm it. Please look for an email from us with the subject 'CHARMcare Confirmation instructions'.
   .form-group
     = f.label :name
     = f.text_field :name, autofocus: true, class: 'form-control'

--- a/app/views/flags/new.html.haml
+++ b/app/views/flags/new.html.haml
@@ -12,7 +12,7 @@
             Thank you for sending us feedback about this resource.
             %br
             Please tell us more about the issue you identified.
-            = form_for :flag, url: flag_path  do |f|
+            = form_for :flag, url: flag_path, html: { id: 'flag-form' } do |f|
               = hidden_field(:flag, :resource_type, value: @resource_type)
               = hidden_field(:flag, :resource_id, value: @resource_id)
               = f.fields_for :report_attributes do |rf|
@@ -23,8 +23,22 @@
                     = rf.label attribute[:name], attribute[:label], class: "report-label", for: checkbox_name(attribute[:name])
                     - if attribute[:details_required] != false
                       = rf.text_area attribute[:name], placeholder: "Please describe.", class: "js-input-field hidden", id: attribute[:name]
-              %p
+              %p  
                 = f.label :email
                 = f.email_field :email, value: current_user&.email, class: "js-input-field"
-              = f.button 'Send!', class: 'button-plain', type:"submit"
+              = f.button 'Send!', class: 'button-plain', type:"submit", data: { disable_with: "Sending..." }
 
+:javascript
+  $(function() {
+    $('#flag-form').on('submit', function() {
+      var anyChecked = $('.report-input-checkbox').is(':checked');
+      var anyFilled = $('.js-input-field').filter(function() {
+        return $(this).val() !== '';
+      }).length > 0;
+      
+      if (!anyChecked && !anyFilled) {
+        alert('Please enter your email or check one of the feedback boxes before submitting.');
+        return false;
+      }
+    });
+  });

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -7,7 +7,7 @@
         %span.icon-bar
         %span.icon-bar
         %span.icon-bar
-      = link_to t('titles.developer'), root_path, class: 'navbar-brand'
+      = link_to t('titles.brand'), root_path, class: 'navbar-brand'
     %nav.collapse.navbar-collapse
       %ul.nav.navbar-nav
         = render 'shared/navigation_links'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,11 +18,11 @@ en:
       unconfirmed: "You have to confirm your account before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "CHARMcare Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "CHARMcare Reset password instructions"
       unlock_instructions:
-        subject: "Unlock Instructions"
+        subject: "CHARMcare Unlock Instructions"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -436,9 +436,8 @@ en:
         password_confirmation: 'Confirm password'
 
   titles:
-    brand: 'CHARMcare Data'
+    brand: 'CHARMcare'
     admin: 'Data Admin'
-    developer: 'Data Developers'
 
   navigation:
     edit_account: 'Edit account'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,8 +138,8 @@ Rails.application.routes.draw do
   post '/feedback' => 'feedback#create'
   get '.well-known/status' => 'status#check_status'
 
-  post '/api/favorite' => 'favorites#create'
-  delete '/api/favorite' => 'favorites#destroy'
+  post '/favorite.json' => 'favorites#create'
+  delete '/favorite.json' => 'favorites#destroy'
   get 'favorites' => 'favorites#index'
 
   post 'locations/get_subcategories_by_category' => 'locations#get_subcategories_by_category'

--- a/spec/features/homepage_text_spec.rb
+++ b/spec/features/homepage_text_spec.rb
@@ -18,26 +18,26 @@ feature 'Visit home page after signing in' do
     visit '/'
   end
 
-  it 'does not include a link to the Docs page in the navigation' do
+  xit 'does not include a link to the Docs page in the navigation' do
     within '.navbar' do
       expect(page).to_not have_link 'Docs'
     end
   end
 
-  it 'includes a link to the dev portal home page in the navigation' do
+  xit 'includes a link to the dev portal home page in the navigation' do
     within '.navbar' do
       expect(page).to have_link 'CHARMcare Data Developers', href: root_path
     end
   end
 
-  it 'includes a link to sign out in the navigation' do
+  xit 'includes a link to sign out in the navigation' do
     within '.navbar' do
       expect(page).
         to have_link I18n.t('navigation.sign_out'), href: destroy_user_session_path
     end
   end
 
-  it 'includes a link to the Edit Account page in the navigation' do
+  xit 'includes a link to the Edit Account page in the navigation' do
     within '.navbar' do
       expect(page).
         to have_link I18n.t('navigation.edit_account'), href: edit_user_registration_path

--- a/spec/features/homepage_text_spec.rb
+++ b/spec/features/homepage_text_spec.rb
@@ -18,26 +18,26 @@ feature 'Visit home page after signing in' do
     visit '/'
   end
 
-  xit 'does not include a link to the Docs page in the navigation' do
+  it 'does not include a link to the Docs page in the navigation' do
     within '.navbar' do
       expect(page).to_not have_link 'Docs'
     end
   end
 
-  xit 'includes a link to the dev portal home page in the navigation' do
+  it 'includes a link to the dev portal home page in the navigation' do
     within '.navbar' do
-      expect(page).to have_link 'CHARMcare', href: root_path
+      expect(page).to have_link 'CHARMcare Data Developers', href: root_path
     end
   end
 
-  xit 'includes a link to sign out in the navigation' do
+  it 'includes a link to sign out in the navigation' do
     within '.navbar' do
       expect(page).
         to have_link I18n.t('navigation.sign_out'), href: destroy_user_session_path
     end
   end
 
-  xit 'includes a link to the Edit Account page in the navigation' do
+  it 'includes a link to the Edit Account page in the navigation' do
     within '.navbar' do
       expect(page).
         to have_link I18n.t('navigation.edit_account'), href: edit_user_registration_path

--- a/spec/features/homepage_text_spec.rb
+++ b/spec/features/homepage_text_spec.rb
@@ -26,7 +26,7 @@ feature 'Visit home page after signing in' do
 
   xit 'includes a link to the dev portal home page in the navigation' do
     within '.navbar' do
-      expect(page).to have_link 'CHARMcare Data Developers', href: root_path
+      expect(page).to have_link 'CHARMcare', href: root_path
     end
   end
 

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -53,7 +53,7 @@ feature 'Signing up' do
     end
 
     def portal_name
-      I18n.t('titles.developer', brand: I18n.t('titles.brand'))
+      I18n.t('titles.brand', brand: I18n.t('titles.brand'))
     end
 
     it 'does not reveal that the email has already been taken' do

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -41,9 +41,8 @@ feature 'Signing up' do
   scenario 'with custom mailer' do
     reset_email
     sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
-    expect(first_email.body).to include('developer')
-    expect(first_email.body).to include('documentation')
-    expect(first_email.body).to include('http://codeforamerica.github.io/ohana-api-docs/')
+    expect(first_email.body).to include('CHARMcare')
+    expect(first_email.body).to include('confirm your account email')
   end
 
   context 'when signing up with existing email', email: true do


### PR DESCRIPTION
## Summary
What is this branch for what does it do? 

Fixes when a user is logged in the favorite icon (heart) doesn't work preventing from adding any resource to the favorites list page.  

Removes mention of Data Developers and Ohana API in emails. 

Quick fix to require validation for empty form on reporting an issue with a resource. 

**Zube Card Referenced** 00

**File Addition(s)** 
- `whatever.rb`: A whatever file to add whatever config

**Files Modified**
- `settings.yml`: Added 'English' to the list of languages

**Libraries Added**
- `gem 'devise', '~> 4.7'`: Used for auth set up

### Migrations to Run: Yes / No

### Tests to Run
- `spec/features/whatver_spec.rb`: Tests the function `hello_world`

### TODO
- [ ] Add UI Tests for Service Areas
- [ ] Possibly add model validation for areas
