### PR TITLE
[BCHDCC-39] - Accessibility Criterion 2.4.2: Page Titled

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
     Rails.configuration.upload_server
   end
 
-    # Appends the site title to the end of the page title.
+  # Appends the site title to the end of the page title.
   # The site title is defined in config/settings.yml.
   # @param page_title [String] the page title from a particular view.
   def title(page_title)

--- a/app/helpers/result_summary_helper.rb
+++ b/app/helpers/result_summary_helper.rb
@@ -1,11 +1,23 @@
 module ResultSummaryHelper
   extend ActionView::Helpers::TextHelper
+  PARAMS_FRIENDLY_NAME = {
+    "main_category" => "Topic",
+    "keyword" => "Keyword"
+  }
 
   def search_results_page_title
-    search_terms = request.query_parameters.except(:utf8).
-                   map { |k, v| "#{k}: #{v}" if v.present? }.
-                   compact.join(', ')
-    "Search results for: #{search_terms}"
+    if search_params_present?
+      search_terms = request.query_parameters.except(:utf8).
+                     map { |k, v| "#{PARAMS_FRIENDLY_NAME[k]}: #{v}" if v.present? }.
+                     compact.join(', ')
+      "Search results for: #{search_terms}"
+    else
+      "All Results"
+    end
+  end
+
+  def search_params_present?
+    request.query_parameters.values.reject(&:blank?).present?
   end
 
   # Formats map result summary text

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,3 +1,4 @@
+- title "Resend Confirmation Instructions"
 .authform
   = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, role: 'form' }) do |f|
     %h3 Resend confirmation instructions

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,3 +1,4 @@
+- title "Change Your Password"
 .authform
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, role: 'form' }) do |f|
     %h3 Change your password

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,3 +1,4 @@
+- title "Forgot Your Password"
 .authform.devise
   = content_tag(:span, nil, class: 'fa fa-key fa-3x', style: "display: block")  
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, role: 'form' }) do |f|

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,3 +1,4 @@
+- title "Edit #{resource_name.to_s.humanize}"
 %h3
   Edit #{resource_name.to_s.humanize}
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, role: 'form' }) do |f|

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,3 +1,4 @@
+- title "Sign Up"
 .authform.devise
   = content_tag(:span, nil, class: 'fa fa-users fa-3x', style: "display: block")  
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { role: 'form', class: 'form' }) do |f|

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,3 +1,4 @@
+- title "Login"
 .authform.devise
   - if resource.class.name == User.name
     = content_tag(:span, nil, class: 'fa fa-key fa-3x', style: "display: block")


### PR DESCRIPTION
## Description
Have a friendly page title for each page that the users visit. 

[WCAG 2.4.2: Page Titled](https://www.w3.org/WAI/WCAG22/Understanding/page-titled.html#:~:text=The%20intent%20of%20this%20Success,read%20or%20interpret%20page%20content.)

The intent of this Success Criterion is to help users find content and orient themselves within it by ensuring that each Web page has a descriptive title. Titles identify the current location without requiring users to read or interpret page content.

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-39](https://app.clickup.com/t/9006094761/BCHDCC-39) - Accessibility Criterion 2.4.2: Page Titled
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to any ancillary pieces that you had to use to close the ticket and
      think would be interesting or valuable for readers of this PR. This could
      include things like Airbrake exceptions, ruby/rails documentation, blog
      posts, etc.-->
<!--- Describe any difficulties that arose during creation and any tickets that
      were created as a result. If you have thoughts on how to make those
      difficulties less difficult in the future but not as part of this PR,
      write down those thoughts. -->

## Screenshots
N/A

**Libraries Added**
N/A

## Migrations to Run: No

## Tests to Run
N/A


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ ] My code follows the code style of this project (https://rubystyle.guide/).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
