### PR TITLE
[BCHDCC-37, 40, 45] - Non-text Content, Focus Order & Images of Text

### DIFF
--- a/app/helpers/name_format_helper.rb
+++ b/app/helpers/name_format_helper.rb
@@ -12,7 +12,7 @@ module NameFormatHelper
   # @param location [Sawyer::Resource] Location Hash returned by API wrapper.
   # @return [String] The location's name wrapped in a span element.
   def name_content_for(location)
-    content_tag 'span', itemprop: 'legalName' do
+    content_tag 'span', itemprop: 'legalName', aria: { label: location.name } do
       content_tag 'span', itemprop: 'name' do
         location.name
       end
@@ -22,7 +22,7 @@ module NameFormatHelper
   # @param location [Sawyer::Resource] Location Hash returned by API wrapper.
   # @return [String] The location's alternate name wrapped in a span element.
   def alternate_name_content_for(location)
-    content_tag 'span', itemprop: 'alternateName' do
+    content_tag 'span', itemprop: 'alternateName', aria: { label: location.alternate_name } do
       location.alternate_name
     end
   end

--- a/app/helpers/result_summary_helper.rb
+++ b/app/helpers/result_summary_helper.rb
@@ -16,7 +16,7 @@ module ResultSummaryHelper
     summary = if total_map_markers == total_results
                 ''
               else
-                " <i class='fa fa-map-marker'></i> <em>"\
+                " <i class='fa fa-map-marker' aria-label='location marker' role='img' tabindex='0'></i> <em>"\
                 "<strong>#{total_map_markers}</strong>/#{total_results} "\
                 "located on map</em>"
               end

--- a/app/javascript/app/detail/character-limited/CharacterLimited.js
+++ b/app/javascript/app/detail/character-limited/CharacterLimited.js
@@ -23,6 +23,7 @@ function CharacterLimited(elm, defaults) {
   function showMore() {
     _elm.innerHTML = _fulltext;
     _showHideElm.innerHTML = defaults.LESS_TEXT;
+    _showHideElm.setAttribute('aria-expanded', 'true');
 
     _elm.appendChild(_showHideElm);
   }
@@ -41,6 +42,7 @@ function CharacterLimited(elm, defaults) {
 
     if (h.length > 0) {
       _showHideElm.innerHTML = defaults.MORE_TEXT;
+      _showHideElm.setAttribute('aria-expanded', 'false');
 
       var html = c + '<span class="moreellipses">' +
                 defaults.ELLIPSES_TEXT +
@@ -52,7 +54,8 @@ function CharacterLimited(elm, defaults) {
     }
   }
 
-  function _linkClicked() {
+  function _linkClicked(event) {
+    event.preventDefault();
     _isShowingMore = !_isShowingMore;
     if (_isShowingMore)
       showMore();
@@ -62,6 +65,9 @@ function CharacterLimited(elm, defaults) {
 
   function _init() {
     _showHideElm = document.createElement('a');
+    _showHideElm.href = "#";
+    _showHideElm.setAttribute('aria-controls', _elm.id);
+    _showHideElm.setAttribute('aria-expanded', 'false');
     _showHideElm.addEventListener('click', _linkClicked, false);
     _fulltext = _elm.innerHTML;
     if(_fulltext.length > defaults.SHOW_CHAR)
@@ -71,11 +77,11 @@ function CharacterLimited(elm, defaults) {
   _init();
 
   return {
-    showMore:showMore,
-    showLess:showLess
+    showMore: showMore,
+    showLess: showLess
   };
 }
 
 export default {
-  create:create
+  create: create
 };

--- a/app/javascript/app/detail/character-limited/character-limiter.js
+++ b/app/javascript/app/detail/character-limited/character-limiter.js
@@ -5,8 +5,8 @@ import CharacterLimited from './CharacterLimited';
 // 'Constants'
 var SHOW_CHAR = 400;
 var SOFT_LIMIT = 100;
-var MORE_TEXT = 'Show more';
-var LESS_TEXT = 'Show less';
+var MORE_TEXT = '<span class=more>(</span>Show more<span>)</span>';
+var LESS_TEXT = '<span class=less>(</span>Show less<span>)</span>';
 var ELLIPSES_TEXT = '…';
 
 function init() {

--- a/app/javascript/app/detail/character-limited/character-limiter.js
+++ b/app/javascript/app/detail/character-limited/character-limiter.js
@@ -3,31 +3,27 @@
 import CharacterLimited from './CharacterLimited';
 
 // 'Constants'
-// How many characters to show.
 var SHOW_CHAR = 400;
-
-// Limit added to SHOW_CHAR if truncated value is less than this value.
 var SOFT_LIMIT = 100;
-
-// Text for showing/hiding more text.
-var MORE_TEXT = '<span class=more>(</span>more<span>)</span>';
-var LESS_TEXT = '<span class=less>(</span>less<span>)</span>';
+var MORE_TEXT = 'Show more';
+var LESS_TEXT = 'Show less';
 var ELLIPSES_TEXT = '…';
 
 function init() {
   var defaults = {
-    SHOW_CHAR:SHOW_CHAR,
-    SOFT_LIMIT:SOFT_LIMIT,
-    MORE_TEXT:MORE_TEXT,
-    LESS_TEXT:LESS_TEXT,
-    ELLIPSES_TEXT:ELLIPSES_TEXT
+    SHOW_CHAR: SHOW_CHAR,
+    SOFT_LIMIT: SOFT_LIMIT,
+    MORE_TEXT: MORE_TEXT,
+    LESS_TEXT: LESS_TEXT,
+    ELLIPSES_TEXT: ELLIPSES_TEXT
   };
   var charLimitedElms = document.querySelectorAll('.character-limited');
   var numberElms = charLimitedElms.length;
-  while( numberElms > 0 )
+  while (numberElms > 0) {
     CharacterLimited.create(charLimitedElms[--numberElms], defaults);
+  }
 }
 
 export default {
-  init:init
+  init: init
 };

--- a/app/javascript/app/search/filter/search-filters.js
+++ b/app/javascript/app/search/filter/search-filters.js
@@ -233,7 +233,7 @@ function _updateSubCategories(){
 
         parentCategoryDiv.classList.add("hoverable");
         parentCategoryDiv.setAttribute("aria-label", "Click enter to expand and collapse filters");
-        parentCategoryDiv.setAttribute("aria-expanded", "false");
+        parentCategoryDiv.setAttribute("aria-expanded", "true");
   
         filterDropdownContainer.classList.add("filter-dropdown-closed");
   
@@ -282,10 +282,6 @@ function _openSection(element) {
     $(item).toggleClass('hide');
   });
 
-  $(element).attr('aria-expanded', function (i, attr) {
-    return attr == 'true' ? 'false' : 'true'
-  });
-
   $(element).toggleClass('selected');
   $($(element).find('i')).toggleClass('fa fa-chevron-right fa fa-chevron-down');
 }
@@ -311,7 +307,10 @@ function _collapseSection(element) {
 
 function _handleHeaderClick(evt) {
   if (evt.key === "Enter" || evt.type === 'click') {
-    _openSection($(evt.currentTarget));
+    let parentCategoryDiv = evt.currentTarget;
+    let isExpanded = parentCategoryDiv.getAttribute('aria-expanded') === 'true';
+    parentCategoryDiv.setAttribute('aria-expanded', (!isExpanded).toString());
+    _openSection($(parentCategoryDiv));
   }
 }
 

--- a/app/views/component/about/_about.html.haml
+++ b/app/views/component/about/_about.html.haml
@@ -1,10 +1,9 @@
 %div.about-container
   .about-summary
-    %img{ src: asset_path(SETTINGS[:site_logo_alt]), alt: "#{SETTINGS[:site_title]} Logo", class: "logo"}
+    %img{ src: asset_path(SETTINGS[:site_logo_alt]), alt: "#{SETTINGS[:site_title]} large logo", class: "logo", aria: { label: t('branding.logo') } }
     = t('views.about.charmcare_summary_html')
-    = link_to SETTINGS[:baltimore_accountable_health_community] do
-      %button.button-plain
-        = t('views.about.learn_more')
+    %button.button-plain{ onclick: "window.location.href='#{SETTINGS[:baltimore_accountable_health_community]}'", aria: { label: t('views.about.learn_more', community: SETTINGS[:baltimore_accountable_health_community]) } }
+      = t('views.about.learn_more')
 
   %h1
     = t('views.about.contact.connect_with_us')
@@ -15,19 +14,15 @@
       = form_tag('/feedback', method: :post) do
         %p
           = label_tag 'organization_name', t('views.about.contact.organization_name')
-          = text_field_tag 'organization_name', nil, class: 'organization-name'
+          = text_field_tag 'organization_name', nil, class: 'organization-name', aria: { label: t('views.about.contact.organization_name') }
         %p
           = label_tag 'name', t('views.about.contact.your_name')
-          = text_field_tag 'name', nil, required: 'true', class: 'name'
+          = text_field_tag 'name', nil, required: 'true', class: 'name', aria: { label: t('views.about.contact.your_name') }
         %p
           = label_tag 'from', t('views.about.contact.your_email')
-          = email_field_tag 'from', nil, required: 'true', class: 'email'
+          = email_field_tag 'from', nil, required: 'true', class: 'email', aria: { label: t('views.about.contact.your_email') }
         %p
           = label_tag 'message', t('views.about.contact.message')
-          = text_area_tag('message',
-                            nil,
-                            rows: '4',
-                            required: 'true',
-                            class: 'comment')
+          = text_area_tag 'message', nil, rows: '4', required: 'true', class: 'comment', aria: { label: t('views.about.contact.message') }
         = hidden_field_tag 'agent', user_agent
-        = button_tag 'Submit', class: 'button-plain'
+        = button_tag t('views.about.contact.submit'), class: 'button-plain', aria: { label: t('views.about.contact.submit') }

--- a/app/views/component/about/_about.html.haml
+++ b/app/views/component/about/_about.html.haml
@@ -1,6 +1,6 @@
 %div.about-container
   .about-summary
-    %img{ src: asset_path(SETTINGS[:site_logo_alt]), alt: "#{SETTINGS[:site_title]} large logo", class: "logo", aria: { label: t('branding.logo') } }
+    %img{ src: asset_path(SETTINGS[:site_logo_alt]), alt: "#{SETTINGS[:site_title]} #{SETTINGS[:site_subtitle]}", class: "logo", aria: { label: "#{t('branding.logo')} large logo" } }
     = t('views.about.charmcare_summary_html')
     %button.button-plain{ onclick: "window.location.href='#{SETTINGS[:baltimore_accountable_health_community]}'", aria: { label: t('views.about.learn_more', community: SETTINGS[:baltimore_accountable_health_community]) } }
       = t('views.about.learn_more')

--- a/app/views/component/detail/_address.html.haml
+++ b/app/views/component/detail/_address.html.haml
@@ -1,9 +1,9 @@
-- if location.address.present? 
+- if location.address.present?
   %span{ itemscope: '', itemtype: 'http://schema.org/PostalAddress', itemprop: 'address' }
     %section.icon-text-block
-      %i.fa.fa-map-marker
-      %h4.annotated-text-block Location
-      %span{ itemprop: 'streetAddress' }><
+      %i.fa.fa-map-marker{ tabindex: "0", role: "img", aria: { label: "Location marker" } }
+      %h4.annotated-text-block= t('labels.location')
+      %span{ itemprop: 'streetAddress' }
         = superscript_ordinals(street_address_for(location.address))
       - if lines == 2
         %br

--- a/app/views/component/detail/_email.html.haml
+++ b/app/views/component/detail/_email.html.haml
@@ -3,7 +3,7 @@
 
 - if email.present?
   %section.email.icon-text-block
-    %i.fa.fa-envelope
+    %i.fa.fa-envelope{'aria-label': 'Email'}
     %span.annotated-text-block
       %h4 Email
     %br  

--- a/app/views/component/detail/_featured_location_badge.html.haml
+++ b/app/views/component/detail/_featured_location_badge.html.haml
@@ -1,13 +1,11 @@
-.featured-location-badge
-    .tooltip
-        %i.fa.fa-info-circle
-        %span.tooltiptext
-            %i.fa.fa-info-circle 
-            %h3
-                What is a CHARMcare Favorite?
-            %p 
-                CHARMcare users have found this resource to be particularly helpful.
-    %br                
-    CHARMcare
-    %br
-    Favorite            
+.featured-location-badge{ tabindex: "0", role: "group", aria: { label: t('labels.charmcare_favorite') } }
+  .tooltip
+    %i.fa.fa-info-circle{ tabindex: "0", role: "img", aria: { label: t('labels.information_on_charmcare_favorites') } }
+    %span.tooltiptext
+      %i.fa.fa-info-circle{ tabindex: "0", role: "img", aria: { label: t('labels.information_on_charmcare_favorites') } }
+      %h3= t('labels.what_is_charmcare_favorite')
+      %p= t('labels.charmcare_favorite_description')
+  %br
+  = SETTINGS[:site_title]
+  %br
+  = t('labels.favorite')

--- a/app/views/component/detail/_location_holiday_schedule.html.haml
+++ b/app/views/component/detail/_location_holiday_schedule.html.haml
@@ -1,6 +1,6 @@
 - if schedules.present?
   %section.schedules.holiday-schedules.icon-text-block
-    %i.fa.fa-clock-o
+    %i.fa.fa-clock-o{'aria-label': 'Hours'}
     %span.annotated-text-block
       %h1 Holiday Hours
     = holiday_hours_for(schedules)

--- a/app/views/component/detail/_location_regular_schedule.html.haml
+++ b/app/views/component/detail/_location_regular_schedule.html.haml
@@ -1,6 +1,6 @@
 - if schedules.present?
   %section.schedules.regular-schedules.icon-text-block
-    %i.fa.fa-clock-o
+    %i.fa.fa-clock-o{'aria-label': 'Hours'}
     %span.annotated-text-block
       %h4 Hours
     %p

--- a/app/views/component/detail/_phones.html.haml
+++ b/app/views/component/detail/_phones.html.haml
@@ -1,8 +1,9 @@
 - if phones.present?
     %section.phone.icon-text-block{ itemscope: '', itemtype: 'http://schema.org/ContactPoint' }
-        %i.fa.fa-phone
+        %span{ tabindex: "0", role: "img", aria: { label: "Phone" } }
+            %i.fa.fa-phone
         %span.annotated-text-block
-            %h4 Phone
+            %h4= t('labels.phone')
         %br  
         - phones.each do |phone|
             = render 'component/detail/phone', phone: phone, show_phone_type_and_department: true

--- a/app/views/component/detail/_phones.html.haml
+++ b/app/views/component/detail/_phones.html.haml
@@ -1,7 +1,7 @@
 - if phones.present?
     %section.phone.icon-text-block{ itemscope: '', itemtype: 'http://schema.org/ContactPoint' }
         %span{ tabindex: "0", role: "img", aria: { label: "Phone" } }
-            %i.fa.fa-phone
+            %i.fa.fa-phone{'aria-label': 'Phone'}
         %span.annotated-text-block
             %h4= t('labels.phone')
         %br  

--- a/app/views/component/detail/_service_website.html.haml
+++ b/app/views/component/detail/_service_website.html.haml
@@ -3,7 +3,7 @@
 
 - if service.website.present?
   %section.website.icon-text-block
-    %i.fa.fa-external-link-square
+    %i.fa.fa-external-link-square{'aria-label': 'Website'}
     %span.annotated-text-block
       %a{ href: service.website, target: '_blank', itemprop: 'url' }
         = format_url(service.website)

--- a/app/views/component/detail/_website.html.haml
+++ b/app/views/component/detail/_website.html.haml
@@ -3,7 +3,7 @@
 
 - if website.present?
   %section.website.icon-text-block
-    %i.fa.fa-external-link-square
+    %i.fa.fa-external-link-square{'aria-label': 'Website'}
     %span.annotated-text-block
       %h4 Website
     %a{ href: website, target: '_blank', itemprop: 'url' }

--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -90,6 +90,7 @@
       - if location.coordinates.present?
         %span.directions.icon-text-block><
           %a{ href: "https://maps.google.com/maps?saddr=current+location&daddr=#{full_address_for(location.address)}", target: '_blank' }
+          %span{ tabindex: "0", role: "img", aria: { label: "Location" } }
             %i.fa.fa-map-marker.fa-lg
             %span.annotated-text-block Get Directions              
 

--- a/app/views/component/locations/detail/_header_summary.html.haml
+++ b/app/views/component/locations/detail/_header_summary.html.haml
@@ -3,18 +3,15 @@
     %span
       %a.button-utility.button-back{ href: "#{locations_url(@query_parameters)}##{location.id}", target: '_self' }
         %i.fa.fa-arrow-left
-        Back
+        %span Back
     %span.header-right><
       %a.button-utility.button-share-email{ href: mailto_url }
         %i.fa.fa-share-square-o.fa-lg
-  
- 
-      %button.fa.fa-heart-o.favorite-toggle.fa-lg
-
+        %span{ "aria-label" => "Share resource via email" }
+      %button.fa.fa-heart-o.favorite-toggle.fa-lg{ "aria-label" => "Add to favorites" }
         
 
   .left-column
     .floating-content.hide
-      %h1
+      %h1{ tabindex: "0", aria: { label: full_name_content_for(location) } }
         = superscript_ordinals(full_name_content_for(location))
-

--- a/app/views/component/locations/results/_body.html.haml
+++ b/app/views/component/locations/results/_body.html.haml
@@ -1,6 +1,6 @@
 %section#results-entries
   - unless search.map_data.empty?
-    = render 'component/locations/results/map_view', search: search
+    = render 'component/locations/results/map_view', search: search, address: @address
 
   - if info_box_key_corresponding_to_keyword.present?
     %section#terminology-box-container

--- a/app/views/component/locations/results/_featured_location.html.haml
+++ b/app/views/component/locations/results/_featured_location.html.haml
@@ -1,11 +1,9 @@
-.featured_location_tag 
-    CHARMcare Favorite
-    %span.tooltip
-        %i.fa.fa-info-circle
-        %span.tooltiptext
-            %i.fa.fa-info-circle 
-            %h3
-                What is a CHARMcare Favorite?
-            %p 
-                CHARMcare users have found this resource to be particularly helpful.    
-    
+.featured_location_tag{ tabindex: "0", role: "group", aria: { label: t('labels.charmcare_favorite') } }
+  %span{ role: "text" }
+    = t('labels.charmcare_favorite')
+  %span.tooltip
+    %i.fa.fa-info-circle{ tabindex: "0", role: "img", aria: { label: t('labels.information_on_charmcare_favorites') } }
+    %span.tooltiptext
+      %i.fa.fa-info-circle{ tabindex: "0", role: "img", aria: { label: t('labels.information_on_charmcare_favorites') } }
+      %h3= t('labels.what_is_charmcare_favorite')
+      %p= t('labels.charmcare_favorite_description')

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -6,7 +6,7 @@
         %section#keyword-search-box.search-box.home-page-search-container
           %div
             = label_tag 'main_category', t('labels.category_search') , class: "main_category"
-            = select_tag :main_category, options_for_select(categories_for_select), include_blank: 'All', class: "category_search_select"
+            = select_tag :main_category, options_for_select(categories_for_select), include_blank: 'All', class: "category_search_select", aria: { labelledby: 'main_category' }
           %div
             %span.home-page-or or
           %div

--- a/app/views/component/search/_box.html.haml
+++ b/app/views/component/search/_box.html.haml
@@ -4,9 +4,10 @@
       %div.search-form
         = label_tag 'prompt', t('labels.homepage_prompt')
         %section#keyword-search-box.search-box.home-page-search-container
+          %legend.sr-only= t('labels.category_search')
           %div
             = label_tag 'main_category', t('labels.category_search') , class: "main_category"
-            = select_tag :main_category, options_for_select(categories_for_select), include_blank: 'All', class: "category_search_select", aria: { labelledby: 'main_category' }
+            = select_tag :main_category, options_for_select(categories_for_select), include_blank: 'All', class: "category_search_select", aria: { labelledby: 'Browse by Topic' }
           %div
             %span.home-page-or or
           %div

--- a/app/views/component/search/_filters.html.haml
+++ b/app/views/component/search/_filters.html.haml
@@ -1,11 +1,9 @@
-
-
 %div#categoryFiltersContainerDiv.category-filters-container
   = label_tag :category_filters, 'Topic Filters', id: 'category-filters-label'
   %hr
 
 - if @main_category_selected_name == ""
-  %div#parent-category.parent-category-label-container{ tabindex: "0", role: "button", aria: { label: 'Select a Topic from above to display additional filters.', expanded: 'true'}}
+  %div#parent-category.parent-category-label-container{ tabindex: "0", role: "button", aria: { label: 'Select a Topic from above to display additional filters.', expanded: 'false'}}
     %legend
       %span#subcategoriesFilterTitle.filter-description-label
         = "Select a Topic from above to display additional filters."
@@ -14,7 +12,7 @@
   %fieldset#subcategoriesList
   
 - else
-  %div#parent-category.parent-category-label-container.hoverable{ tabindex: "0", role: "button", aria: { label: 'Click enter to expand and collapse filters', expanded: 'true'}}
+  %div#parent-category.parent-category-label-container.hoverable{ tabindex: "0", role: "button", aria: { label: 'Click enter to expand and collapse filters', expanded: 'false'}}
     %legend
       %span#subcategoriesFilterTitle.parent-category-label
         = "#{category_filters_title(@main_category_selected_name)}"

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,6 +1,6 @@
 %footer#app-footer
   %div#footer-container
-    %img#app-footer{ src: asset_path(SETTINGS[:bchd_logo]) }
+    %img#app-footer{ src: asset_path(SETTINGS[:bchd_logo]), alt: "Baltimore City Health Department Logo" }
     #google-translate-container
     // Add Google Translate script callback
     :javascript

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -1,24 +1,24 @@
 %header#content-header
   %h1#logo
-    %a{ href: '/', target: '_self' }
+    %a{ href: '/', target: '_self', aria: { label: t('branding.logo') } }
       %img{ src: asset_path(SETTINGS[:site_logo]), alt: "#{SETTINGS[:site_title]} Logo" }
   %h2= t('branding.header', location: t('branding.location'))
   %nav
     %ul
       %li
-        %a.popup-trigger.popup-default#about-btn{ href: '/about#about-box' }
+        %a.popup-trigger.popup-default#about-btn{ href: '/about#about-box', aria: { label: t('navigation.about') } }
           About
       - if user_signed_in?
         %li
-          %a.popup-trigger.popup-default#about-btn{ href: '/favorites' }
+          %a.popup-trigger.popup-default#favorites-btn{ href: '/favorites', aria: { label: t('navigation.favorites') } }
             Favorites
         %li
-          %a.popup-trigger.popup-account#user-btn{ href: edit_user_registration_path }
+          %a.popup-trigger.popup-account#user-btn{ href: edit_user_registration_path, aria: { label: t('navigation.edit_profile') } }
             %div.button-logged-in
               = current_user.first_name[0]&.upcase || current_user.email[0].upcase
         %li
-          = link_to t('navigation.sign_out'), destroy_user_session_path, method: 'delete'
+          = link_to t('navigation.sign_out'), destroy_user_session_path, method: 'delete', aria: { label: t('navigation.sign_out') }
       - else
         %li
-          %a.popup-trigger.popup-account.button-small#user-btn{ href: new_user_session_path }
+          %a.popup-trigger.popup-account.button-small#user-btn{ href: new_user_session_path, aria: { label: t('users.login') } }
             = t('users.login')

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -7,11 +7,11 @@
     %ul
       %li
         %a.popup-trigger.popup-default#about-btn{ href: '/about#about-box', aria: { label: t('navigation.about') } }
-          About
+          = t('navigation.about')
       - if user_signed_in?
         %li
           %a.popup-trigger.popup-default#favorites-btn{ href: '/favorites', aria: { label: t('navigation.favorites') } }
-            Favorites
+            = t('navigation.favorites')
         %li
           %a.popup-trigger.popup-account#user-btn{ href: edit_user_registration_path, aria: { label: t('navigation.edit_profile') } }
             %div.button-logged-in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -478,6 +478,8 @@ en:
       in %{location}.
     header: 'Connect with resources in %{location}'
     location: 'Baltimore City'
+    logo: 'Charm care'
+
 
   date:
     day_names:
@@ -679,6 +681,7 @@ en:
         your_name: 'Your Name*'
         your_email: 'Your Email*'
         message: 'Message*'
+        submit: 'Submit'
     feedback:
       issue_link: 'File an issue on GitHub'
       issue_link_url: 'https://github.com/codeforamerica/Ohana-Web-Search/issues'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -442,10 +442,13 @@ en:
 
   navigation:
     edit_account: 'Edit account'
+    edit_profile: 'Edit user profile'
     sign_in: 'Sign in'
     sign_in_with: 'Sign in with'
     sign_up: 'Sign up'
     sign_out: 'Sign out'
+    about: 'About'
+    favorites: 'Favorites'
     forgot_your_password: 'Forgot your password?'
     no_confirmation_instructions: "Didn't receive confirmation instructions?"
     no_unlock_instructions: "Didn't receive unlock instructions?"
@@ -478,7 +481,7 @@ en:
       in %{location}.
     header: 'Connect with resources in %{location}'
     location: 'Baltimore City'
-    logo: 'Charm care'
+    logo: 'Charm care community health access and resource module'
 
 
   date:
@@ -535,6 +538,13 @@ en:
       filters_menu_title: 'Refine your search'
     topic_prompt: 'Choose a topic below to begin a search'
     vaccination-link-text: 'Register for a COVID-19 Vaccination'
+    phone: 'Phone'
+    location: 'Location'
+    favorite: 'Favorite'
+    charmcare_favorite: 'CHARMcare Favorite'
+    information_on_charmcare_favorites: 'Information on Charm care favorites'
+    what_is_charmcare_favorite: 'What is a CHARMcare Favorite?'
+    charmcare_favorite_description: 'CHARMcare users have found this resource to be particularly helpful.'
 
   location_fields:
     accessibility: 'Accessibility'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -558,6 +558,7 @@ site_logo_prod_asset_url: http://www.charmcare.org/assets/CHARMcareLogo-01-87192
 # a location called "Health Insurance TeleCenter", the browser would display
 # "Health Insurance TeleCenter | Ohana Web Search" as the page title.
 site_title: CHARMcare
+site_subtitle: Community Health Access and Resource Module
 
 ###########################
 #


### PR DESCRIPTION
## Summary
What is this branch for what does it do? 

These changes add alt text, aria labels, and ensure the user is able to navigate through the pages using keyboard controls. 

Accessibility Criterion 1.1.1: Non-text Content -
As a screen reader user, I want to hear a description of an image, so I can understand the purpose behind the image and what context it brings to the web content. 

Accessibility Criterion 2.4.3: Focus Order -
As a user, I want to be able to navigate sequentially on focus, so that I can tab through web content in a meaningful and efficient sequence.

Accessibility Criterion 1.4.5: Images of Text -
As a user that has a visual disability, I want images that don't include text, so I can access labels using my screen reader.

**Zube Card Referenced** 00

**File Addition(s)** 
- `whatever.rb`: A whatever file to add whatever config

**Files Modified**
- `settings.yml`: Added 'English' to the list of languages

**Libraries Added**
- `gem 'devise', '~> 4.7'`: Used for auth set up

### Migrations to Run: Yes / No

### Tests to Run
- `spec/features/whatver_spec.rb`: Tests the function `hello_world`

### TODO
- [ ] Add UI Tests for Service Areas
- [ ] Possibly add model validation for areas
