### PR TITLE
Quick fix - Adjust spacing on results header

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -564,7 +564,7 @@ body {
 
 .results-header {
   position: absolute;
-  top: 485px;
+  top: 470px;
   right: 0;
   z-index: 9999;
   max-height: 45px;

--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -564,7 +564,7 @@ body {
 
 .results-header {
   position: absolute;
-  top: 470px;
+  top: 476px;
   right: 0;
   z-index: 9999;
   max-height: 45px;


### PR DESCRIPTION
## Description
<!--- Describe your changes in some detail by answering questions such as: -->
<!---   Why is this change needed? -->
<!---   How does it address the issue?-->

Quick fix to spacing on the results header (e.g. "313 Results").

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-###](https://app.clickup.com/t/9006094761/BCHDCC-XX) - TICKET TITLE
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to any ancillary pieces that you had to use to close the ticket and
      think would be interesting or valuable for readers of this PR. This could
      include things like Airbrake exceptions, ruby/rails documentation, blog
      posts, etc.-->
<!--- Describe any difficulties that arose during creation and any tickets that
      were created as a result. If you have thoughts on how to make those
      difficulties less difficult in the future but not as part of this PR,
      write down those thoughts. -->

## Screenshots
<!--- If this is a UI change, put a relevant screenshot(s) here with a 
      description of what is in it. -->

<img width="802" alt="Screenshot 2024-09-25 at 12 37 33 PM" src="https://github.com/user-attachments/assets/e1154435-405f-4104-ba04-1517de223ccb">


**Libraries Added**


## Migrations to Run: Yes / **No**

## Tests to Run


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [x] My code follows the code style of this project (https://rubystyle.guide/).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

