### PR TITLE
[BCHDCC-80] Keyword Match Notification Banner

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -665,6 +665,13 @@ body {
   }
 }
 
+#results-entries {
+  .no-exact-match-banner ~ .results-header {
+    top: 550px;
+    position: absolute !important;
+  }
+}
+
 .detail-header {
   top: 0;
 }
@@ -704,6 +711,10 @@ body {
 
   a {
     text-decoration: none;
+  }
+
+  @media (max-width: 767px) {
+    padding-top: 20px;
   }
 
   // No results styling.
@@ -765,6 +776,21 @@ body {
     display: table-row;
   }
 }
+
+.no-exact-match-banner {
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 4px;
+  padding: 15px;
+  margin-bottom: 20px;
+  margin-right: 20px;
+  margin-left: 20px;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 600;
+  color: #495057;
+}
+
 //=================================================================================
 // Results - terminology infobox. Certain keywords display an informational box
 // above the search results. See app/helpers/info_box_helper.rb for more info.

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -13,7 +13,7 @@ class LocationsController < ApplicationController
 
     # Performs the actual search using the processed search parameters above
     set_coordinates
-    locations = LocationsSearch.new(
+    @locations_search = LocationsSearch.new(
       accessibility: search_params[:accessibility],
       category_ids: search_params[:category_ids],
       distance: search_params[:distance],
@@ -27,7 +27,8 @@ class LocationsController < ApplicationController
       per_page: search_params[:per_page],
       languages: search_params[:languages],
       matched_category: @matched_category
-    ).search.load&.objects
+    )
+    locations = @locations_search.search.load&.objects
     @search = Search.new(locations, params)
 
 
@@ -45,6 +46,8 @@ class LocationsController < ApplicationController
     @selected_categories = params[:categories] || []
     @keyword_matched_category = @matched_category.present? && params[:keyword].present?
     @clear_categories = params[:keyword].present? && !@matched_category
+
+    @exact_match_found = @locations_search.exact_match_found?
 
     # caches the search results and renders the view
     cache_page(@search.locations) if @search.locations.present?
@@ -166,7 +169,6 @@ class LocationsController < ApplicationController
     search_params[:main_category] = @matched_category.parent&.name || @matched_category.name
     @main_category_selected_name = search_params[:main_category]
     @main_category_selected_id = @matched_category.parent&.id || @matched_category.id
-    search_params[:keyword] = nil
     search_params[:category_ids] = [@matched_category.id]
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -209,7 +209,6 @@ class LocationsController < ApplicationController
   def match_keyword_to_subcategory(keyword)
     return nil if keyword.blank?
 
-    Category.where("LOWER(name) = ?", keyword.downcase).first ||
-        Category.where("LOWER(name) LIKE ?", "%#{keyword.downcase}%").first
+    Category.where("LOWER(name) = ?", keyword.downcase).first
   end
 end

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -37,48 +37,29 @@ class LocationsSearch
   def exact_match_found?
     keyword_to_use = keywords || attributes[:keyword]
 
-    if keyword_to_use.blank? && matched_category.blank?
-      return false
-    end
-
-    if matched_category.present?
-      return true
-    end
-
+    return true if matched_category.present?
     return false if keyword_to_use.blank?
 
-    exact_match_query = index.query(bool: {
+    combined_query = index.query(bool: {
       should: [
+        # Exact matches
         { term: { "organization_name_exact": { value: keyword_to_use.downcase } } },
         { term: { "name_exact": { value: keyword_to_use.downcase } } },
         { term: { "categories_exact": { value: keyword_to_use.downcase } } },
-        { term: { "sub_categories_exact": { value: keyword_to_use.downcase } } },
         { match_phrase: { "organization_name": { query: keyword_to_use, slop: 0 } } },
         { match_phrase: { "name": { query: keyword_to_use, slop: 0 } } },
         { match_phrase: { "categories": { query: keyword_to_use, slop: 0 } } },
-        { match_phrase: { "sub_categories": { query: keyword_to_use, slop: 0 } } }
-      ]
+        # Partial matches
+        { match: { "organization_name": { query: keyword_to_use, operator: "and" } } },
+        { match: { "name": { query: keyword_to_use, operator: "and" } } },
+        { match: { "categories": { query: keyword_to_use, operator: "and" } } },
+        { match: { "organization_tags": { query: keyword_to_use, operator: "and" } } }
+      ],
+      minimum_should_match: 1
     })
 
-    results = exact_match_query.count
-    result = results > 0
-
-    # not an exact match, check for partial matches
-    if !result
-      partial_match_query = index.query(bool: {
-        should: [
-          { match: { "organization_name": { query: keyword_to_use, operator: "and" } } },
-          { match: { "name": { query: keyword_to_use, operator: "and" } } },
-          { match: { "categories": { query: keyword_to_use, operator: "and" } } },
-          { match: { "sub_categories": { query: keyword_to_use, operator: "and" } } }
-        ]
-      })
-
-      partial_results = partial_match_query.count
-      result = partial_results > 0
-    end
-
-    result
+    results = combined_query.count
+    results > 0
   end
 
   private
@@ -126,7 +107,6 @@ class LocationsSearch
 
   def order
     index.order(
-      featured_at: { missing: "_last", order: "asc" },
       "_score": { "order": "desc" },
       updated_at: { order: "desc" }
     )
@@ -240,7 +220,7 @@ class LocationsSearch
   end
 
   def build_query
-    if matched_category.is_a?(Category)
+    base_query = if matched_category.is_a?(Category)
       {
         bool: {
           should: [
@@ -250,10 +230,48 @@ class LocationsSearch
         }
       }
     elsif keywords.present?
-      { multi_match: { query: keywords, fields: %w[organization_name^20 name^16 categories^14 organization_tags^12 tags^10 service_tags^8 description^6 service_names^4 service_descriptions^2 keywords], fuzziness: 'AUTO' } }
+      {
+        bool: {
+          should: [
+            # Exact phrase matches
+            { match_phrase: { "name": { query: keywords, boost: 100 } } },
+            { match_phrase: { "organization_name": { query: keywords, boost: 100 } } },
+            { match_phrase: { "description": { query: keywords, boost: 50 } } },
+            { match_phrase: { "service_descriptions": { query: keywords, boost: 50 } } },
+
+            # All words must match
+            { match: { "name": { query: keywords, boost: 10, operator: "and" } } },
+            { match: { "organization_name": { query: keywords, boost: 10, operator: "and" } } },
+            { match: { "description": { query: keywords, boost: 5, operator: "and" } } },
+            { match: { "service_descriptions": { query: keywords, boost: 5, operator: "and" } } },
+
+            # Partial matches
+            { multi_match: {
+                query: keywords,
+                fields: %w[categories^14 organization_tags^12 tags^10 service_tags^8 service_names^4 keywords],
+                type: "best_fields",
+                fuzziness: 'AUTO'
+              }
+            }
+          ]
+        }
+      }
     else
       { match_all: {} }
     end
+
+    {
+      function_score: {
+        query: base_query,
+        functions: [
+          {
+            filter: { exists: { field: "featured_at" } },  # featured resources have slightly higher weight on searches
+            weight: 1.2
+          }
+        ],
+        boost_mode: "multiply"
+      }
+    }
   end
 
   def apply_filters(query)
@@ -276,21 +294,8 @@ class LocationsSearch
     query
   end
 
-  def apply_keyword_filter(query)
-    query.query(multi_match: {
-      query: keywords,
-      fields: %w[organization_name^20 name^16 categories^14 organization_tags^12 tags^10 service_tags^8 description^6 service_names^4 service_descriptions^2 keywords],
-      fuzziness: 'AUTO'
-    })
-  end
-
-  def apply_category_filter(query)
-    query.filter(terms: { category_ids: category_ids })
-  end
-
   def apply_sorting(query)
     query.order(
-      featured_at: { missing: "_last", order: "asc" },
       "_score": { "order": "desc" },
       updated_at: { order: "desc" }
     )

--- a/app/views/component/locations/results/_body.html.haml
+++ b/app/views/component/locations/results/_body.html.haml
@@ -1,4 +1,6 @@
 %section#results-entries
+  = render 'component/locations/results/no_exact_match_banner'
+
   - unless search.map_data.empty?
     = render 'component/locations/results/map_view', search: search, address: @address
 

--- a/app/views/component/locations/results/_header.html.haml
+++ b/app/views/component/locations/results/_header.html.haml
@@ -1,2 +1,3 @@
-%header.results-header#floating-results-header
-  = render 'component/locations/results/header_summary', search: search
+- header_class = @exact_match_found ? '' : 'no-exact-match'
+%header.results-header#floating-results-header{class: header_class}
+  = render 'component/locations/results/header_summary', search: search 

--- a/app/views/component/locations/results/_no_exact_match_banner.html.haml
+++ b/app/views/component/locations/results/_no_exact_match_banner.html.haml
@@ -1,0 +1,7 @@
+- if !@exact_match_found && @search.locations.present? && params[:keyword].present?
+  %div.no-exact-match-banner{role: "alert", "aria-live": "polite"}
+    %h2.visuallyhidden Search Results Information
+    %p
+      No exact matches found. 
+      %span{"aria-label": "Showing related results for #{params[:keyword]}"}
+        Showing related results for "#{params[:keyword]}".

--- a/spec/searches/locations_search_spec.rb
+++ b/spec/searches/locations_search_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe LocationsSearch, :elasticsearch do
 
       results = search({keywords: 'Salvation Army'}).objects
 
-      expect(results[0].id).to eq(featured_location.id)
-      expect(results[1].id).to eq(location_name_exact_match.id)
-      expect(results[2].id).to eq(location_name_partial_match.id)
+      expect(results[0].id).to eq(location_name_exact_match.id)
+      expect(results[1].id).to eq(location_name_partial_match.id)
+      expect(results[2].id).to eq(featured_location.id)
       expect(results[3].id).to eq(location_with_org_matching_tags.id)
       expect(results).not_to include(location_random_attributes)
     end
@@ -66,8 +66,8 @@ RSpec.describe LocationsSearch, :elasticsearch do
 
       results = search({keywords: 'Financial Aid And Loans'}).objects
 
-      expect(results[0].id).to be(featured_location.id)
-      expect(results[1].id).to be(location_organization_match.id)
+      expect(results[0].id).to be(location_organization_match.id)
+      expect(results[1].id).to be(featured_location.id)
       expect(results[2].id).to be(location_category_service_match.id)
     end
 
@@ -95,8 +95,8 @@ RSpec.describe LocationsSearch, :elasticsearch do
 
       results = search({keywords: 'Financial Aid And Loans'}).objects
 
-      expect(results[0].id).to be(featured_location.id)
-      expect(results[1].id).to be(location_name_exact_match.id)
+      expect(results[0].id).to be(location_name_exact_match.id)
+      expect(results[1].id).to be(featured_location.id)
       expect(results[2].id).to be(location_sub_category_service_match.id)
     end
   end
@@ -518,8 +518,8 @@ RSpec.describe LocationsSearch, :elasticsearch do
       results = search({keywords: "#{term_1} #{term_2}"}).objects
 
       expect(results.first.id).to eq(location_desc_and_match.id)
-      expect(results.second.id).to eq(location_service_name_and_match.id)
-      expect(results.third.id).to eq(location_service_dec_and_match.id)
+      expect(results.second.id).to eq(location_service_dec_and_match.id)
+      expect(results.third.id).to eq(location_service_name_and_match.id)
       expect(results).not_to include(location_random_terms)
     end
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in some detail by answering questions such as: -->
<!---   Why is this change needed? -->
<!---   How does it address the issue?-->

If there is no exact match when a user searches a keyword, inform the user that the keyword they searched did not populate exact match results, but related results are being displayed. 

For example, when a user searches for "Baby food" and the combination of the 2 words were not found, the page should display a banner indicating the user that the exact match was not found, but similar/partial matches will be displayed.

If the word being searched is a partial match, but not an exact match, the no exact matches banner does not get displayed. For example, if the user searches "covid", there are many locations with organizations names with the word "covid" in the title, but none of them have an exact match to only the keyword "covid". Although it isn't an exact match, it is a partial match in the title. 

Keyword match notification banner is accessible to screen readers. 

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-80](https://app.clickup.com/t/9006094761/BCHDCC-80) - Implement a notification banner when search is not a match
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to any ancillary pieces that you had to use to close the ticket and
      think would be interesting or valuable for readers of this PR. This could
      include things like Airbrake exceptions, ruby/rails documentation, blog
      posts, etc.-->
<!--- Describe any difficulties that arose during creation and any tickets that
      were created as a result. If you have thoughts on how to make those
      difficulties less difficult in the future but not as part of this PR,
      write down those thoughts. -->

There was no frontend design that I could follow, this is a simple banner that can be updated with a different design in the future. This is a first, simple design iteration. 

This ticket depends on parts of the implementation in [BCHDCC-79](https://github.com/bchd/bahc-ohana-api/pull/331)

## Screenshots
<!--- If this is a UI change, put a relevant screenshot(s) here with a 
      description of what is in it. -->

### No results with an exact result match for "baby food"
<img width="1020" alt="Screenshot 2024-10-11 at 3 56 27 PM" src="https://github.com/user-attachments/assets/532ade49-5b55-4b36-a6f6-aa0b35ef9b77">

### mobile
<img width="334" alt="Screenshot 2024-10-11 at 3 56 53 PM" src="https://github.com/user-attachments/assets/4d588810-7181-4633-92e4-0dffb0f552d3">

### No keyword match banner notification for search "covid" because there are results that have "covid" in their title
<img width="940" alt="Screenshot 2024-10-11 at 3 58 04 PM" src="https://github.com/user-attachments/assets/304774c4-3466-4a79-9bfe-41855aa558cc">

**Libraries Added**

## Migrations to Run: Yes / **No**

## Tests to Run


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [x] My code follows the code style of this project (https://rubystyle.guide/).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

