### PR TITLE
[BCHDCC-87] Include in the location results row, a list of services offered in the location

### DIFF
--- a/app/assets/stylesheets/components/_icon-text-block.scss
+++ b/app/assets/stylesheets/components/_icon-text-block.scss
@@ -9,6 +9,10 @@
   position: relative;
   padding: 5px 0 5px 0;
 
+  .fa.fa-handshake-o {
+    font-size: $font_size_100;
+  }
+
   .fa {
     position: absolute;
     width: $font_size_110;

--- a/app/views/component/detail/_service_list.html.haml
+++ b/app/views/component/detail/_service_list.html.haml
@@ -1,7 +1,7 @@
 %section.content
   %span{ itemprop: 'serviceName' }
     %section.icon-text-block
-      %i.fa.fa-tags{ tabindex: "0", role: "img", aria: { label: "Services marker" } }
+      %i.fa.fa-handshake-o{ tabindex: "0", role: "img", aria: { label: "Services marker" } }
       %h4.annotated-text-block= t('labels.services')
     - location.services.each_with_index do |service, i|
       - if i < location.services.size-1

--- a/app/views/component/detail/_service_list.html.haml
+++ b/app/views/component/detail/_service_list.html.haml
@@ -1,0 +1,10 @@
+%section.content
+  %span{ itemprop: 'serviceName' }
+    %section.icon-text-block
+      %i.fa.fa-tags{ tabindex: "0", role: "img", aria: { label: "Services marker" } }
+      %h4.annotated-text-block= t('labels.services')
+    - location.services.each_with_index do |service, i|
+      - if i < location.services.size-1
+        %span.name #{service.name},
+      - else
+        %span.name #{service.name}

--- a/app/views/component/locations/results/_list_view.html.haml
+++ b/app/views/component/locations/results/_list_view.html.haml
@@ -32,6 +32,10 @@
               - if location.short_desc.present?
                 .short-desc-list-view
                   = render_markdown(location.short_desc)
+
+          - if location.services.present? && location.services.size > 0
+            = render 'component/detail/service_list', location: location
+
           - if user_signed_in?
             - services = Location.get(location.id)[:services]
             - if services.present? && services.size > 0


### PR DESCRIPTION
## Description
<!--- Describe your changes in some detail by answering questions such as: -->
<!---   Why is this change needed? -->
<!---   How does it address the issue?-->

Added list of services offered in each location to the results list view.

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-87](https://app.clickup.com/t/9006094761/BCHDCC-87) - Include in the location results row, a list of services offered in the location
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to any ancillary pieces that you had to use to close the ticket and
      think would be interesting or valuable for readers of this PR. This could
      include things like Airbrake exceptions, ruby/rails documentation, blog
      posts, etc.-->
<!--- Describe any difficulties that arose during creation and any tickets that
      were created as a result. If you have thoughts on how to make those
      difficulties less difficult in the future but not as part of this PR,
      write down those thoughts. -->

## Screenshots
<!--- If this is a UI change, put a relevant screenshot(s) here with a 
      description of what is in it. -->
Screenshot of a list of results where the services offered at each location are included below the location description
<img width="1180" alt="Screenshot 2024-11-14 at 5 17 03 PM" src="https://github.com/user-attachments/assets/8a8bbd32-554d-4dc5-bafb-2bda86736ee0">


**Libraries Added**
None

## Migrations to Run: No

## Tests to Run
None


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ ] My code follows the code style of this project (https://rubystyle.guide/).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

