### PR TITLE
[BCHDCC-86] Have a service related fields on Location weight higher than any other fields

### DIFF
--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -178,15 +178,15 @@ class LocationsSearch
 
     query.query(bool: {
       should: [
-        { term: { "organization_name_exact": { value: keywords.downcase, boost: 160 } } },
-        { term: { "name_exact": { value: keywords.downcase, boost: 120 } } },
-        { term: { "categories_exact": { value: keywords.downcase, boost: 80 } } },
-        { term: { "sub_categories_exact": { value: keywords.downcase, boost: 40 } } }
+        { term: { "service_names_exact": { value: keywords.downcase, boost: 10 } } },
+        { term: { "service_description_exact": { value: keywords.downcase, boost: 8 } } },
+        { term: { "service_tags_exact": { value: keywords.downcase, boost: 5 } } },
+        { term: { "name": { value: keywords.downcase, boost: 1 } } }
       ],
       must: [{
         multi_match: {
           query: keywords,
-          fields: %w[organization_name^20 name^16 categories^14 organization_tags^12 tags^10 service_tags^8 description^6 service_names^4 service_descriptions^2 keywords],
+          fields: %w[service_names^10 service_descriptions^8 service_tags^7 organization_name^4 name^3 categories^2 organization_tags^1 tags description keywords],
           fuzziness: 'AUTO'
         }
       }]
@@ -233,35 +233,35 @@ class LocationsSearch
       }
     elsif keywords.present?
       {
+
         bool: {
           should: [
             # Exact phrase matches
-            { match_phrase: { "organization_name": { query: keywords, boost: 200 } } },
-            { match_phrase: { "name": { query: keywords, boost: 120 } } },
-            { match_phrase: { "description": { query: keywords, boost: 50 } } },
-            { match_phrase: { "service_descriptions": { query: keywords, boost: 50 } } },
+            { match_phrase: { "service_name": { query: keywords, boost: 10 } } },
+            { match_phrase: { "service_descriptions": { query: keywords, boost: 8 } } },
+            { match_phrase: { "service_tags": { query: keywords, boost: 5 } } },
+            { match_phrase: { "name": { query: keywords, boost: 1 } } },
 
             # All words must match
-            { match: { "organization_name": { query: keywords, boost: 150, operator: "and" } } },
-            { match: { "name": { query: keywords, boost: 15, operator: "and" } } },
-            { match: { "description": { query: keywords, boost: 5, operator: "and" } } },
-            { match: { "service_descriptions": { query: keywords, boost: 5, operator: "and" } } },
+            { match: { "service_name": { query: keywords, boost: 10, operator: "and" } } },
+            { match: { "service_descriptions": { query: keywords, boost: 8, operator: "and" } } },
+            { match: { "service_tags": { query: keywords, boost: 5, operator: "and" } } },
+            { match: { "name": { query: keywords, boost: 1, operator: "and" } } },
 
             # Partial and fuzzy matches
             { multi_match: {
                 query: keywords,
                 fields: %w[
-                  organization_name^100
-                  name^16
-                  categories^12
-                  organization_tags^10
-                  tags^8
-                  service_tags^6
-                  description^4
-                  service_descriptions^4
-                  service_names^2
-                  keywords
-                ],
+                  service_names^10
+                  service_descriptions^8
+                  service_tags^7
+                  organization_name^4
+                  name^3
+                  categories^2
+                  organization_tags^1
+                  tags
+                  description
+                  keywords],
                 type: "best_fields",
                 fuzziness: 'AUTO',
                 prefix_length: 2

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -237,13 +237,13 @@ class LocationsSearch
         bool: {
           should: [
             # Exact phrase matches
-            { match_phrase: { "service_name": { query: keywords, boost: 10 } } },
+            { match_phrase: { "service_names": { query: keywords, boost: 10 } } },
             { match_phrase: { "service_descriptions": { query: keywords, boost: 8 } } },
             { match_phrase: { "service_tags": { query: keywords, boost: 5 } } },
             { match_phrase: { "name": { query: keywords, boost: 1 } } },
 
             # All words must match
-            { match: { "service_name": { query: keywords, boost: 10, operator: "and" } } },
+            { match: { "service_names": { query: keywords, boost: 10, operator: "and" } } },
             { match: { "service_descriptions": { query: keywords, boost: 8, operator: "and" } } },
             { match: { "service_tags": { query: keywords, boost: 5, operator: "and" } } },
             { match: { "name": { query: keywords, boost: 1, operator: "and" } } },

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -497,21 +497,6 @@ describe "GET 'search'" do
     end
   end
 
-  context 'with organization name as a keyword query' do
-    before do
-      @loc1 = create(:nearby_loc, name: 'some parent name')
-      @loc2 = create(:location)
-      LocationsIndex.reset!
-    end
-
-    it 'should return organization locations on the top of search' do
-      get api_search_index_url(keyword: 'parent')
-
-      expect(json[0]['name']).to eq(@loc2.name)
-      expect(json[1]['name']).to eq(@loc1.name)
-    end
-  end
-
   context 'it should order the locations' do
     before do
       @organization = create(:organization)


### PR DESCRIPTION


## Description
<!--- Describe your changes in some detail by answering questions such as: -->
<!---   Why is this change needed? -->
<!---   How does it address the issue?-->

Changed weight and boost values, as well as used fields, to increase the score of matches on service related fields.

See document linked to ticket for detailed analysis of changes, including screenshots of search results with the previous and new weight and boost values.

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-86](https://app.clickup.com/t/9006094761/BCHDCC-XX) - Have a service related fields on Location weight higher than any other fields
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to any ancillary pieces that you had to use to close the ticket and
      think would be interesting or valuable for readers of this PR. This could
      include things like Airbrake exceptions, ruby/rails documentation, blog
      posts, etc.-->
<!--- Describe any difficulties that arose during creation and any tickets that
      were created as a result. If you have thoughts on how to make those
      difficulties less difficult in the future but not as part of this PR,
      write down those thoughts. -->

## Screenshots
<!--- If this is a UI change, put a relevant screenshot(s) here with a 
      description of what is in it. -->

**Libraries Added**
None

## Migrations to Run: No

## Tests to Run
None


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ ] My code follows the code style of this project (https://rubystyle.guide/).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

