### PR TITLE
BCHDCC-96 Results are sorted differently when doing a search using keywords vs main categories

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -15,6 +15,7 @@ class LocationsController < ApplicationController
     set_coordinates
     @locations_search = LocationsSearch.new(
       accessibility: search_params[:accessibility],
+      main_category_name: @main_category_selected_name,
       category_ids: search_params[:category_ids],
       distance: search_params[:distance],
       keywords: search_params[:keyword],

--- a/app/views/component/detail/_service_list.html.haml
+++ b/app/views/component/detail/_service_list.html.haml
@@ -5,8 +5,8 @@
       %h4.annotated-text-block= t('labels.services')
     - location.services.each_with_index do |service, i|
       - if i < location.services.size-1
-        %a{ href: "#{location_link_for(location)}/##{service_id_for(service.name)}"}
+        %a{ href: "#{location_link_for(location)}##{service_id_for(service.name)}"}
           #{service.name},
       - else
-        %a{ href: "#{location_link_for(location)}/##{service_id_for(service.name)}"}
+        %a{ href: "#{location_link_for(location)}##{service_id_for(service.name)}"}
           #{service.name}


### PR DESCRIPTION
## Description
<!--- Describe your changes in some detail by answering questions such as: -->
<!---   Why is this change needed? -->
<!---   How does it address the issue?-->

Modified code to use weighted query for searches with a main category selected and no keywords

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-96](https://app.clickup.com/t/9006094761/BCHDCC-96) - Results are sorted differently when doing a search using keywords vs main categories
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to any ancillary pieces that you had to use to close the ticket and
      think would be interesting or valuable for readers of this PR. This could
      include things like Airbrake exceptions, ruby/rails documentation, blog
      posts, etc.-->
<!--- Describe any difficulties that arose during creation and any tickets that
      were created as a result. If you have thoughts on how to make those
      difficulties less difficult in the future but not as part of this PR,
      write down those thoughts. -->

## Screenshots
<!--- If this is a UI change, put a relevant screenshot(s) here with a 
      description of what is in it. -->

**Libraries Added**
None

## Migrations to Run: No

## Tests to Run
None


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ ] My code follows the code style of this project (https://rubystyle.guide/).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

