### PR TITLE
[BCHDCC-113] Have the service row to be expanded when a user clicks on a service name in the index page

### DIFF
--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -281,16 +281,31 @@
   initPrintButton();
 
 
-  document.querySelectorAll('.service-row').forEach( row => {
-    row.addEventListener("click", toggleServiceCard);
-    row.addEventListener("keydown", toggleServiceCard);
-  });
+  // services-related functionality
+  let targetServiceRow;
 
-  document.querySelectorAll('.service-item').forEach( item => {
-    item.addEventListener("click", openServiceCard);
-    item.addEventListener("keydown", openServiceCard);
-  });
+  enableServiceRelatedFunctionality();
 
+  function enableServiceRelatedFunctionality(){
+    // add event listeners to each service item in summary box
+    document.querySelectorAll('.service-item').forEach( item => {
+      item.addEventListener("click", openServiceCard);
+      item.addEventListener("keydown", openServiceCard);
+    });
+
+    // add event listeners to each service row
+    document.querySelectorAll('.service-row').forEach( row => {
+      row.addEventListener("click", toggleServiceCard);
+      row.addEventListener("keydown", toggleServiceCard);
+    });
+
+    // if the location hash property exists, open the corresponding service details section
+    if (window.location.hash){
+      serviceName = window.location.hash.substring(1);
+      targetServiceRow = document.getElementById(serviceName);
+      toggleServiceCard(new Event('click'));
+    }
+  }
 
   // Open service details card
   function openServiceCard(e){
@@ -326,7 +341,11 @@
       return false;
     }
 
-    const serviceRowId = e.target.id;
+    if (e.target) {
+      targetServiceRow = e.target;
+    }
+
+    const serviceRowId = targetServiceRow.id;
     const i = serviceRowId.split("-").pop();
 
     let chevron = document.getElementById(`service-chevron-${i}`);
@@ -344,7 +363,7 @@
     let serviceCardElement = document.getElementById(`service-card-${i}`);
     serviceCardElement.classList.toggle("collapsed");
 
-    e.target.setAttribute("aria-expanded", serviceCardElement.classList.contains("collapsed")? "false" : "true");
+    targetServiceRow.setAttribute("aria-expanded", serviceCardElement.classList.contains("collapsed")? "false" : "true");
   }
 
   function isEventValid(e){


### PR DESCRIPTION
## Description
<!--- Describe your changes in some detail by answering questions such as: -->
<!---   Why is this change needed? -->
<!---   How does it address the issue?-->
Added JavaScript code to open a service detail section on the location page when the corresponding service hyperlink is clicked on the results page

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-113](https://app.clickup.com/t/9006094761/BCHDCC-113) - Have the service row to be expanded when a user clicks on a service name in the index page
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to any ancillary pieces that you had to use to close the ticket and
      think would be interesting or valuable for readers of this PR. This could
      include things like Airbrake exceptions, ruby/rails documentation, blog
      posts, etc.-->
<!--- Describe any difficulties that arose during creation and any tickets that
      were created as a result. If you have thoughts on how to make those
      difficulties less difficult in the future but not as part of this PR,
      write down those thoughts. -->

## Screenshots
<!--- If this is a UI change, put a relevant screenshot(s) here with a 
      description of what is in it. -->

**Libraries Added**
None

## Migrations to Run: No

## Tests to Run

## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ ] My code follows the code style of this project (https://rubystyle.guide/).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

