### PR TITLE
[BCHDCC-106 Ranking] - Rank results considering the amount of non completed flags

### DIFF
--- a/app/chewy/locations_index.rb
+++ b/app/chewy/locations_index.rb
@@ -52,4 +52,5 @@ class LocationsIndex < Chewy::Index
   field :updated_at, type: 'date'
   field :zipcode, value: -> { address.try(:postal_code) }
   field :languages, type: 'keyword', value: -> { services.map(&:languages).concat(languages).flatten.uniq.reject(&:blank?) }
+  field :open_flags, type: 'integer', value: -> {Flag.where(resource_id: id, completed_at: nil, resource_type: "Location").count}
 end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -107,6 +107,8 @@ class Flag < ApplicationRecord
     serialized_attributes
   end
 
+  update_index('locations') { Location.find(self.resource_id) }
+
   # from api again
   private
 

--- a/app/searches/locations_search.rb
+++ b/app/searches/locations_search.rb
@@ -255,6 +255,15 @@ class LocationsSearch
           {
             filter: { exists: { field: "featured_at" } },
             weight: 1.2
+          },
+          {
+            gauss: {
+              open_flags: {
+                origin: 0,
+                scale: 5,
+                decay: 0.75
+              }
+            }
           }
         ],
         boost_mode: "multiply"
@@ -327,6 +336,7 @@ class LocationsSearch
   def apply_sorting(query)
     query.order(
       "_score": { "order": "desc" },
+      open_flags: { order: "asc" },
       updated_at: { order: "desc" }
     )
   end


### PR DESCRIPTION
## Description
<!--- Describe your changes in some detail by answering questions such as: -->
<!---   Why is this change needed? -->
<!---   How does it address the issue?-->

 - Indexed number of open flags to each location
 - Location index updates when a flag is created, edited, completed
 - Added a decay function to reduce the ElasticSearch score based on the number of open flags

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-106](https://app.clickup.com/t/9006094761/BCHDCC-106) - Ranking - Rank results considering the amount of non completed flags
<!--- Why is this change required? What problem does it solve? -->
<!--- Link to any ancillary pieces that you had to use to close the ticket and
      think would be interesting or valuable for readers of this PR. This could
      include things like Airbrake exceptions, ruby/rails documentation, blog
      posts, etc.-->
<!--- Describe any difficulties that arose during creation and any tickets that
      were created as a result. If you have thoughts on how to make those
      difficulties less difficult in the future but not as part of this PR,
      write down those thoughts. -->

## Screenshots
<!--- If this is a UI change, put a relevant screenshot(s) here with a 
      description of what is in it. -->

**Libraries Added**
No

## Migrations to Run: No

## Tests to Run
- `spec/searches/locations_search_spec.rb`: Tests locations search


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [x] My code follows the code style of this project (https://rubystyle.guide/).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

