### PR TITLE
[BCHDCC-124 / 125] Admin Categories Index 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
           ELASTIC_PASSWORD: password
           discovery.type: single-node
           xpack.security.enabled: true
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     environment:
       ASSET_HOST: example.com
       DEFAULT_PER_PAGE: '30'
@@ -136,7 +137,6 @@ jobs:
       - run: unset NODE_OPTIONS && ./bin/rails tailwindcss:build # build tailwind before tests run
       - run: yarn build
       - run: bundle exec rspec --format documentation --color
-      - run: bundle exec rake chewy:reset
 
 workflows:
   setup-lint-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           POSTGRES_DB: ohana_api_test
           POSTGRES_USER: root
           POSTGRES_HOST_AUTH_METHOD: trust
-      - image: elasticsearch:7.17.0
+      - image: elasticsearch:7.17.26
         environment:
           ELASTIC_PASSWORD: password
           discovery.type: single-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ jobs:
       - run: unset NODE_OPTIONS && ./bin/rails tailwindcss:build # build tailwind before tests run
       - run: yarn build
       - run: bundle exec rspec --format documentation --color
+      - run: bundle exec rake chewy:reset
 
 workflows:
   setup-lint-test:

--- a/app/assets/javascripts/admin/categories_manager.js
+++ b/app/assets/javascripts/admin/categories_manager.js
@@ -1,0 +1,3 @@
+$(document).on('turbolinks:load', function() {
+  console.log("Categories Manager Loaded")
+});

--- a/app/assets/javascripts/admin/categories_manager.js
+++ b/app/assets/javascripts/admin/categories_manager.js
@@ -1,3 +1,5 @@
 $(document).on('turbolinks:load', function() {
-  console.log("Categories Manager Loaded")
+  $('#categories-list').find('.category_list_element_name_container').click(function(e) {
+      console.log(e.target)
+    });  
 });

--- a/app/assets/javascripts/admin/categories_manager.js
+++ b/app/assets/javascripts/admin/categories_manager.js
@@ -1,16 +1,20 @@
 $(document).on('turbolinks:load', function() {
   $('#categories-list').find('.category_list_element_name_container').click(function(e) {
-      toggle_subcategory_visibility(e.currentTarget);
+      toggle_subcategory_visibility_by_category(e.currentTarget);
     });  
 
   $("#categories-list").find('.category_list_element_name_container').on("keydown", function(e) {
     if (e.which === 13) {
-      toggle_subcategory_visibility(e.currentTarget);
+      toggle_subcategory_visibility_by_category(e.currentTarget);
       e.preventDefault(); 
       }
     });  
 
-  function toggle_subcategory_visibility(element) {
+  $('#expand_all').click(function(e) {
+      toggle_global_subcategory_visibility(e.currentTarget);
+    });    
+
+  function toggle_subcategory_visibility_by_category(element) {
     let subcategories = $(`#${element.id}_subcategories`)
     let chevron = $(element).children('.fa')
     subcategories.toggleClass('hide');
@@ -20,6 +24,23 @@ $(document).on('turbolinks:load', function() {
     } else {
       element.ariaExpanded = "true";
       chevron.addClass('fa-chevron-down').removeClass('fa-chevron-right');
+    }
+  };  
+
+  function toggle_global_subcategory_visibility(element) {
+    let all_chevrons = $('#categories-list').find('.category_list_element_name_container .fa');
+    let all_subcategories = $('#categories-list').find('.subcategories_container');
+
+    if (element.ariaExpanded === "true") {
+      element.innerText = "Expand all";
+      element.ariaExpanded = "false";
+      all_chevrons.addClass('fa-chevron-right').removeClass('fa-chevron-down');
+      all_subcategories.addClass('hide');
+    } else {
+      element.innerText = "Collapse all";
+      element.ariaExpanded = "true";
+      all_chevrons.addClass('fa-chevron-down').removeClass('fa-chevron-right');
+      all_subcategories.removeClass('hide');
     }
   };  
 });

--- a/app/assets/javascripts/admin/categories_manager.js
+++ b/app/assets/javascripts/admin/categories_manager.js
@@ -1,5 +1,25 @@
 $(document).on('turbolinks:load', function() {
   $('#categories-list').find('.category_list_element_name_container').click(function(e) {
-      console.log(e.target)
+      toggle_subcategory_visibility(e.currentTarget);
     });  
+
+  $("#categories-list").find('.category_list_element_name_container').on("keydown", function(e) {
+    if (e.which === 13) {
+      toggle_subcategory_visibility(e.currentTarget);
+      e.preventDefault(); 
+      }
+    });  
+
+  function toggle_subcategory_visibility(element) {
+    let subcategories = $(`#${element.id}_subcategories`)
+    let chevron = $(element).children('.fa')
+    subcategories.toggleClass('hide');
+    if (element.ariaExpanded === "true") {
+      element.ariaExpanded = "false";
+      chevron.addClass('fa-chevron-right').removeClass('fa-chevron-down');
+    } else {
+      element.ariaExpanded = "true";
+      chevron.addClass('fa-chevron-down').removeClass('fa-chevron-right');
+    }
+  };  
 });

--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -463,7 +463,6 @@ a.boxed-action:active {
   border-bottom: 3px solid #706f6f7b;
   width: 100%;
   margin-top: 10px;
-  cursor: pointer;
 }
 
 .category_list_element_name_container {
@@ -471,6 +470,7 @@ a.boxed-action:active {
   width: 85%; 
   padding-left: 5px;
   z-index: 10;
+  cursor: pointer;
 }
 
 .subcategory_list_element_container {
@@ -480,5 +480,12 @@ a.boxed-action:active {
 }
 
 .subcategories_container {
-  margin-bottom: 30px;
+  margin-bottom: 40px;
+}
+
+.expand_all_categories {
+  display: inline;
+  cursor: pointer;
+  text-decoration: underline;
+  color: #337ab7;
 }

--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -459,3 +459,19 @@ a.boxed-action:active {
   margin-top: 15px;
 }
 
+.category_list_element_container {
+  border-bottom: 3px solid #706f6f7b;
+  width: 100%;
+  margin-top: 10px;
+  cursor: pointer;
+}
+
+.subcategory_list_element_container {
+  border-bottom: 2px solid #E0E0E0;
+  width: 100%;
+  margin-top: 10px;
+}
+
+.subcategories_container {
+  margin-bottom: 30px;
+}

--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -466,6 +466,13 @@ a.boxed-action:active {
   cursor: pointer;
 }
 
+.category_list_element_name_container {
+  float:left; 
+  width: 85%; 
+  padding-left: 5px;
+  z-index: 10;
+}
+
 .subcategory_list_element_container {
   border-bottom: 2px solid #E0E0E0;
   width: 100%;

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -5,7 +5,18 @@ class Admin
     layout 'admin'
 
     def index
-      @categories = Category.all.select{ |c| c.depth == 0 }.sort_by(&:name)
+      all_categories = Category.all.sort_by(&:name)
+      @categories_with_subcategories = assign_children_to_parent_categories(all_categories)
+    end
+
+    private
+
+    def assign_children_to_parent_categories(categories)
+      parent_categories = categories.select{ |c| c.depth == 0 }
+      categories_with_subcategories = parent_categories.map{ |parent_category| 
+        subcategories = categories.select{ |c| c.parent_id == parent_category.id   }
+        { parent_category: parent_category, subcategories: subcategories }
+      }
     end
   end
 end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,0 +1,11 @@
+class Admin
+  class CategoriesController < ApplicationController
+    include ActionView::Helpers::TextHelper
+    before_action :authenticate_admin!
+    layout 'admin'
+
+    def index
+      @categories = Category.unarchived.select{ |c| c.depth == 0 }
+    end
+  end
+end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -5,7 +5,7 @@ class Admin
     layout 'admin'
 
     def index
-      @categories = Category.unarchived.select{ |c| c.depth == 0 }
+      @categories = Category.all.select{ |c| c.depth == 0 }.sort_by(&:name)
     end
   end
 end

--- a/app/views/admin/categories/_category_list_element.html.haml
+++ b/app/views/admin/categories/_category_list_element.html.haml
@@ -1,11 +1,20 @@
-%div.tag_list_element_container
+- parent_category = category[:parent_category]
+- subcategories = category[:subcategories]
+%div.category_list_element_container
   %div.tag_list_element_name_container
+    %i.fa.fa-chevron-down
     %span
-      = category.name
+      = parent_category.name
   %div.tag_list_element_actions_container
     %span
-      = link_to fa_icon("edit"), edit_admin_category_path(category.id), class: "tag_edit_icon"
+      = link_to fa_icon("edit"), edit_admin_category_path(parent_category.id), class: "tag_edit_icon"
     %span
-      = link_to fa_icon("trash"), admin_category_path(category.id), method: :delete, data: { confirm: "Are you sure to delete #{category.name} category?" }, class: "tag_delete_icon"
+      = link_to fa_icon("trash"), admin_category_path(parent_category.id), method: :delete, data: { confirm: "Are you sure to delete #{parent_category.name} category?" }, class: "tag_delete_icon"
   %div{style: "clear: both;"} 
+- if subcategories.present?
+  %div.subcategories_container  
+    - subcategories.each do |subcategory| 
+      = render "subcategory_list_element", category: subcategory
+
+
 

--- a/app/views/admin/categories/_category_list_element.html.haml
+++ b/app/views/admin/categories/_category_list_element.html.haml
@@ -1,8 +1,8 @@
 - parent_category = category[:parent_category]
 - subcategories = category[:subcategories]
-%div.category_list_element_container
-  %div.category_list_element_name_container
-    %i.fa.fa-chevron-down
+%div.category_list_element_container 
+  %div.category_list_element_name_container[parent_category]{ tabIndex: 0, role: "button", aria: { label: 'Click enter to expand and collapse subcategories', expanded: 'false'}}
+    %i.fa.fa-chevron-right
     %span
       = parent_category.name
   %div.tag_list_element_actions_container
@@ -12,7 +12,7 @@
       = link_to fa_icon("trash"), admin_category_path(parent_category.id), method: :delete, data: { confirm: "Are you sure to delete #{parent_category.name} category?" }, class: "tag_delete_icon"
   %div{style: "clear: both;"} 
 - if subcategories.present?
-  %div.subcategories_container  
+  %div.subcategories_container.hide{ id: "category_#{parent_category.id}_subcategories"}  
     - subcategories.each do |subcategory| 
       = render "subcategory_list_element", category: subcategory
 

--- a/app/views/admin/categories/_category_list_element.html.haml
+++ b/app/views/admin/categories/_category_list_element.html.haml
@@ -1,7 +1,7 @@
 - parent_category = category[:parent_category]
 - subcategories = category[:subcategories]
 %div.category_list_element_container
-  %div.tag_list_element_name_container
+  %div.category_list_element_name_container
     %i.fa.fa-chevron-down
     %span
       = parent_category.name

--- a/app/views/admin/categories/_category_list_element.html.haml
+++ b/app/views/admin/categories/_category_list_element.html.haml
@@ -1,7 +1,7 @@
 - parent_category = category[:parent_category]
 - subcategories = category[:subcategories]
 %div.category_list_element_container 
-  %div.category_list_element_name_container[parent_category]{ tabIndex: 0, role: "button", aria: { label: 'Click enter to expand and collapse subcategories', expanded: 'false'}}
+  %div.category_list_element_name_container[parent_category]{ tabIndex: 0, role: "button", aria: { label: "Click enter to expand and collapse #{parent_category.name} subcategories", expanded: 'false'}}
     %i.fa.fa-chevron-right
     %span
       = parent_category.name

--- a/app/views/admin/categories/_category_list_element.html.haml
+++ b/app/views/admin/categories/_category_list_element.html.haml
@@ -1,0 +1,11 @@
+%div.tag_list_element_container
+  %div.tag_list_element_name_container
+    %span
+      = category.name
+  %div.tag_list_element_actions_container
+    %span
+      = link_to fa_icon("edit"), edit_admin_category_path(category.id), class: "tag_edit_icon"
+    %span
+      = link_to fa_icon("trash"), admin_category_path(category.id), method: :delete, data: { confirm: "Are you sure to delete #{category.name} category?" }, class: "tag_delete_icon"
+  %div{style: "clear: both;"} 
+

--- a/app/views/admin/categories/_subcategory_list_element.html.haml
+++ b/app/views/admin/categories/_subcategory_list_element.html.haml
@@ -1,0 +1,10 @@
+%div.subcategory_list_element_container
+  %div.tag_list_element_name_container
+    %span
+      = category.name
+  %div.tag_list_element_actions_container
+    %span
+      = link_to fa_icon("edit"), edit_admin_category_path(category.id), class: "tag_edit_icon"
+    %span
+      = link_to fa_icon("trash"), admin_category_path(category.id), method: :delete, data: { confirm: "Are you sure to delete #{category} category?" }, class: "tag_delete_icon"
+  %div{style: "clear: both;"} 

--- a/app/views/admin/categories/index.html.haml
+++ b/app/views/admin/categories/index.html.haml
@@ -4,7 +4,8 @@
   - if current_admin.super_admin?
     %p
       As a super admin, you have access to all categories in the database. Please make updates responsibly.
-
+  %div.expand_all_categories#expand_all{ tabIndex: 0, role: "button", aria: { label: "Click enter to expand and collapse all subcategories", expanded: 'false'}} 
+    Expand All
   %div
   - if @categories_with_subcategories.empty?
     %span

--- a/app/views/admin/categories/index.html.haml
+++ b/app/views/admin/categories/index.html.haml
@@ -11,7 +11,6 @@
       No results found
 
   - if @categories_with_subcategories.present?
-    %p
+    %ul#categories-list
       - @categories_with_subcategories.each do |category|
-        %ul
-          = render "category_list_element", category: category
+        = render "category_list_element", category: category

--- a/app/views/admin/categories/index.html.haml
+++ b/app/views/admin/categories/index.html.haml
@@ -6,12 +6,12 @@
       As a super admin, you have access to all categories in the database. Please make updates responsibly.
 
   %div
-  - if @categories.empty?
+  - if @categories_with_subcategories.empty?
     %span
       No results found
 
-  - if @categories.present?
+  - if @categories_with_subcategories.present?
     %p
-      - @categories.each do |category|
+      - @categories_with_subcategories.each do |category|
         %ul
           = render "category_list_element", category: category

--- a/app/views/admin/categories/index.html.haml
+++ b/app/views/admin/categories/index.html.haml
@@ -1,0 +1,17 @@
+%h1 Category Manager
+
+%div.tag_index_main_container
+  - if current_admin.super_admin?
+    %p
+      As a super admin, you have access to all categories in the database. Please make updates responsibly.
+
+  %div
+  - if @categories.empty?
+    %span
+      No results found
+
+  - if @categories.present?
+    %p
+      - @categories.each do |category|
+        %ul
+          = render "category_list_element", category: category

--- a/app/views/admin/shared/_navigation_links.html.haml
+++ b/app/views/admin/shared/_navigation_links.html.haml
@@ -19,6 +19,8 @@
       = link_to "Analytics", admin_analytics_path
     %li
       = link_to "Tags", admin_tags_path
+    %li
+      = link_to "Categories", admin_categories_path
 
   %li
     = link_to t('navigation.sign_out'), destroy_admin_session_path, method: 'delete'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,7 @@ en:
       organizations: 'Organizations'
       locations: 'Locations'
       services: 'Services'
+      categories: 'Categories'
       update_capacity: 'Update Capacity'
       csv_section: 'CSV'
       programs: 'Programs'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
     end
     resources :programs, except: :show
     resources :services, only: :index
-    resources :categories, only: :index
+    resources :categories
 
     resources :flags
     resources :flag_categories

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
     end
     resources :programs, except: :show
     resources :services, only: :index
+    resources :categories, only: :index
 
     resources :flags
     resources :flag_categories

--- a/spec/features/admin/categories/visit_categories_spec.rb
+++ b/spec/features/admin/categories/visit_categories_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+feature 'Categories page' do
+  context 'when not signed in' do
+    before do
+      visit '/admin/categories'
+    end
+
+    it 'redirects to the admin sign in page' do
+      expect(current_path).to eq(new_admin_session_path)
+    end
+
+    it 'prompts the user to sign in or sign up' do
+      expect(page).
+        to have_content 'You need to sign in or sign up before continuing.'
+    end
+
+    it 'does not include a link to categories in the navigation' do
+      within '.navbar' do
+        expect(page).not_to have_link I18n.t('admin.buttons.categories'), href: admin_categories_path
+      end
+    end
+  end
+
+  context 'when signed in as admin' do
+    before do
+      login_admin
+      visit '/admin/categories'
+    end
+
+    it 'does not include a link to categories in the navigation' do
+      within '.navbar' do
+        expect(page).not_to have_link I18n.t('admin.buttons.categories'), href: admin_categories_path
+      end
+    end
+  end
+
+  context 'when signed in as super admin' do
+    before do
+      @health_category = create(:health, ancestry: nil)
+      @jobs_category = create(:jobs, ancestry: nil)
+
+      login_super_admin
+      visit '/admin/categories'
+    end
+
+    it 'displays instructions for editing categories' do
+      expect(page).to have_content 'As a super admin'
+    end
+
+    it 'shows all categories' do
+      expect(page).to have_content @health_category.name
+      expect(page).to have_content @jobs_category.name
+    end
+  end
+end

--- a/spec/features/admin/categories/visit_categories_spec.rb
+++ b/spec/features/admin/categories/visit_categories_spec.rb
@@ -39,6 +39,7 @@ feature 'Categories page' do
     before do
       @health_category = create(:health, ancestry: nil)
       @jobs_category = create(:jobs, ancestry: nil)
+      @jobs_subcategory = create(:category, ancestry: @jobs_category.id.to_s)
 
       login_super_admin
       visit '/admin/categories'
@@ -51,6 +52,10 @@ feature 'Categories page' do
     it 'shows all categories' do
       expect(page).to have_content @health_category.name
       expect(page).to have_content @jobs_category.name
+    end
+
+    it 'shows subcategories' do
+      expect(page).to have_content @jobs_subcategory.name
     end
   end
 end


### PR DESCRIPTION
## Description
Adds a new Categories page to the admin panel. 

Shows a list of main categories which can be clicked to expand their subcategories. 

Truly shows ALL categories which is different from how the front page works - the front page / search results page use the unarchived scope which only displays categories which have at least one unarchived service assigned to them. This won't work here because later we'll need to be able to create new categories and have them be visible even with no services yet assigned. So, we show them all. 

Has an Expand/Collapse All button which expands/collapses all subcategories. 

Has edit / delete buttons as a design placeholder but they don't work yet, that functionality will be added in subsequent tickets. 

## Motivation and Context
BCHDCC-124
BCHDCC-125

## Screenshots
<img width="942" height="1143" alt="Screenshot 2026-03-25 at 9 02 05 AM" src="https://github.com/user-attachments/assets/909477ad-4d46-4457-b869-6e5d33f0d987" />

<img width="928" height="1166" alt="Screenshot 2026-03-25 at 9 02 26 AM" src="https://github.com/user-attachments/assets/2f4ecc62-db86-4156-ab3e-dfa403fb9bbb" />

## Tests to Run
- 'spec/features/admin/categories/visit_categories_spec.rb'


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ x] My code follows the code style of this project (https://rubystyle.guide/).
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

