### PR TITLE
[BCHDCC-127] Add Categories

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -26,6 +26,25 @@ class Admin
       end
     end
 
+    def new
+      @category = Category.new
+      authorize @category
+    end
+
+    def create
+      permitted_params = params.require(:category).permit(:name)
+
+      @category = Category.new(name: permitted_params["name"])
+      authorize @category
+
+      if @category.save
+        redirect_to admin_categories_path,
+                    notice: "Category '#{@category.name}' was successfully created."
+      else
+        render :new
+      end
+    end
+
     private
 
     def assign_children_to_parent_categories(categories)

--- a/app/views/admin/categories/index.html.haml
+++ b/app/views/admin/categories/index.html.haml
@@ -4,6 +4,9 @@
   - if current_admin.super_admin?
     %p
       As a super admin, you have access to all categories in the database. Please make updates responsibly.
+  %div.tag_add_new_button_container
+    = link_to " + Add New Category".html_safe, new_admin_category_path, class: 'btn btn-primary'
+  %div{style: "clear: both;"}    
   %div.expand_all_categories#expand_all{ tabIndex: 0, role: "button", aria: { label: "Click enter to expand and collapse all subcategories", expanded: 'false'}} 
     Expand All
   %div

--- a/app/views/admin/categories/new.html.haml
+++ b/app/views/admin/categories/new.html.haml
@@ -1,0 +1,5 @@
+<h1>New Category</h1>
+= render 'error_messages', category: @category
+
+= form_for [:admin, @category], url: admin_categories_path, html: { method: :post } do |f| 
+  = render 'form', f: f

--- a/spec/features/admin/categories/create_category_spec.rb
+++ b/spec/features/admin/categories/create_category_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+feature 'Update name' do
+  background do
+    @category = create(:category)
+    login_super_admin
+    visit '/admin/categories'
+  end
+
+  scenario 'with valid name' do
+    click_link "Add New Category"
+    fill_in 'category_name', with: 'Youth Counseling'
+    click_button 'Save'
+    expect(page).to have_content "Category 'Youth Counseling' was successfully created."
+  end
+end


### PR DESCRIPTION
## Description
Allows admins to add new categories from the admin category manager.

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-127](https://app.clickup.com/t/9006094761/BCHDCC-127) - Add Categories

## Screenshots
<img width="907" height="741" alt="Screenshot 2026-03-31 at 4 10 31 PM" src="https://github.com/user-attachments/assets/f26f185a-2ec3-4e42-8302-aa2ef61e7736" />
<img width="944" height="429" alt="Screenshot 2026-03-31 at 4 10 46 PM" src="https://github.com/user-attachments/assets/31045fb4-5328-416d-9263-a9c5aeedb1b4" />


## Tests to Run
- `spec/features/admin/categories/create_category_spec.rb`

## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [x ] My code follows the code style of this project (https://rubystyle.guide/).
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

