### PR TITLE
[BCHDCC-128] Add Subcategories

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -28,13 +28,16 @@ class Admin
 
     def new
       @category = Category.new
+      if params[:ancestry].present?
+        @parent_category = Category.find_by(id: params[:ancestry])
+      end
       authorize @category
     end
 
     def create
-      permitted_params = params.require(:category).permit(:name)
+      permitted_params = params.require(:category).permit(:name, :ancestry)
 
-      @category = Category.new(name: permitted_params["name"])
+      @category = Category.new(name: permitted_params["name"], ancestry: permitted_params["ancestry"])
       authorize @category
 
       if @category.save

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -34,7 +34,7 @@ class Admin
     end
 
     def create
-      @category = Category.new(name: category_params["name"], ancestry: category_params["ancestry"])
+      @category = Category.new(category_params)
       authorize @category
 
       if @category.save

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -18,7 +18,7 @@ class Admin
       @category = Category.find(params[:id])
       authorize @category
 
-      if @category.update(name: category_params["name"])
+      if @category.update(category_params)
         redirect_to admin_categories_path, notice: 'Category was successfully updated.'
       else
         render :edit

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -17,9 +17,8 @@ class Admin
     def update
       @category = Category.find(params[:id])
       authorize @category
-      permitted_params = params.require(:category).permit(:name)
 
-      if @category.update(name: permitted_params["name"])
+      if @category.update(name: category_params["name"])
         redirect_to admin_categories_path, notice: 'Category was successfully updated.'
       else
         render :edit
@@ -35,9 +34,7 @@ class Admin
     end
 
     def create
-      permitted_params = params.require(:category).permit(:name, :ancestry)
-
-      @category = Category.new(name: permitted_params["name"], ancestry: permitted_params["ancestry"])
+      @category = Category.new(name: category_params["name"], ancestry: category_params["ancestry"])
       authorize @category
 
       if @category.save
@@ -56,6 +53,10 @@ class Admin
         subcategories = categories.select{ |c| c.parent_id == parent_category.id   }
         { parent_category: parent_category, subcategories: subcategories }
       }
+    end
+
+    def category_params
+      params.require(:category).permit(:name, :ancestry)
     end
   end
 end

--- a/app/views/admin/categories/_category_list_element.html.haml
+++ b/app/views/admin/categories/_category_list_element.html.haml
@@ -11,10 +11,12 @@
     %span
       = link_to fa_icon("trash"), admin_category_path(parent_category.id), method: :delete, data: { confirm: "Are you sure to delete #{parent_category.name} category?" }, class: "tag_delete_icon"
   %div{style: "clear: both;"} 
-- if subcategories.present?
-  %div.subcategories_container.hide{ id: "category_#{parent_category.id}_subcategories"}  
-    - subcategories.each do |subcategory| 
-      = render "subcategory_list_element", category: subcategory
+%div.subcategories_container.hide{ id: "category_#{parent_category.id}_subcategories"}  
+  - subcategories.each do |subcategory| 
+    = render "subcategory_list_element", category: subcategory
+  %div.mt-15
+    = link_to " + Add New #{parent_category.name} Subcategory".html_safe, new_admin_category_path(ancestry: parent_category.id), class: 'btn btn-primary'
+  %div{style: "clear: both;"}        
 
 
 

--- a/app/views/admin/categories/_form.html.haml
+++ b/app/views/admin/categories/_form.html.haml
@@ -2,6 +2,9 @@
 = f.label :name
 = f.text_field :name, required: true, maxlength: 50, class: 'form-control'
 
+- if @parent_category
+  = f.hidden_field :ancestry, value: parent_category.id
+
 %div.tag_form_buttons_container
   = f.submit 'Save', class: 'btn btn-primary'
   = link_to 'Back', admin_categories_path, class: 'btn btn-primary'

--- a/app/views/admin/categories/new.html.haml
+++ b/app/views/admin/categories/new.html.haml
@@ -5,5 +5,7 @@
   <h1>New Category</h1>
 = render 'error_messages', category: @category
 
+%p New categories will not appear in search filters until they have been assigned to at least one service. 
+
 = form_for [:admin, @category], url: admin_categories_path, html: { method: :post } do |f| 
   = render 'form', f: f, parent_category: @parent_category

--- a/app/views/admin/categories/new.html.haml
+++ b/app/views/admin/categories/new.html.haml
@@ -1,5 +1,9 @@
-<h1>New Category</h1>
+
+- if @parent_category.present?
+  <h1>New #{@parent_category.name} Subcategory</h1>
+- else
+  <h1>New Category</h1>
 = render 'error_messages', category: @category
 
 = form_for [:admin, @category], url: admin_categories_path, html: { method: :post } do |f| 
-  = render 'form', f: f
+  = render 'form', f: f, parent_category: @parent_category

--- a/app/views/admin/services/forms/_categories.html.haml
+++ b/app/views/admin/services/forms/_categories.html.haml
@@ -9,4 +9,4 @@
   = field_set_tag nil, id: 'categories' do
     = f.label :services
     = categories_expand_button
-    = nested_categories(Category.unarchived.arrange(order: :name))
+    = nested_categories(Category.all.arrange(order: :name))

--- a/spec/features/admin/categories/create_category_spec.rb
+++ b/spec/features/admin/categories/create_category_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Update name' do
+feature 'Create Category' do
   background do
     @category = create(:category)
     login_super_admin

--- a/spec/features/admin/categories/create_subcategory_spec.rb
+++ b/spec/features/admin/categories/create_subcategory_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+feature 'Create Subcategory' do
+  background do
+    @category = create(:jobs)
+    login_super_admin
+    visit '/admin/categories'
+  end
+
+  scenario 'with valid name' do
+    click_link "Add New Jobs Subcategory"
+    expect(page).to have_content "New Jobs Subcategory"
+    fill_in 'category_name', with: 'Jobs Subcategory'
+    click_button 'Save'
+    expect(page).to have_content "Category 'Jobs Subcategory' was successfully created."
+  end
+end


### PR DESCRIPTION
## Description
Allows super admins to add subcategories through the admin category manager. 

Also changes the services page category picker to show all categories instead of "unarchived" ones. In this context unarchived means that it already had a service attached. This will allow new categories and subcategories to be connected to services, allowing the category to appear in the search filters. 

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-128](https://app.clickup.com/t/9006094761/BCHDCC-128) - Add Subcategories

## Tests to Run
- `spec/features/admin/categories/create_subcategory_spec.rb`


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ x] My code follows the code style of this project (https://rubystyle.guide/).
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

