### PR TITLE
[BCHDCC-130] Delete Subcategories

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require jquery
-// = require jquery_ujs
 //= require turbolinks
 //= require bootstrap-sprockets
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,7 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery_ujs
+// = require jquery_ujs
 //= require turbolinks
 //= require bootstrap-sprockets
 

--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -489,3 +489,9 @@ a.boxed-action:active {
   text-decoration: underline;
   color: #337ab7;
 }
+
+.category_edit_icon {
+  color: #47a094;
+  font-size: 25px;
+  margin-left: 37px;
+}

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -28,13 +28,16 @@ class Admin
 
     def new
       @category = Category.new
+      if params[:ancestry].present?
+        @parent_category = Category.find_by(id: params[:ancestry])
+      end
       authorize @category
     end
 
     def create
-      permitted_params = params.require(:category).permit(:name)
+      permitted_params = params.require(:category).permit(:name, :ancestry)
 
-      @category = Category.new(name: permitted_params["name"])
+      @category = Category.new(name: permitted_params["name"], ancestry: permitted_params["ancestry"])
       authorize @category
 
       if @category.save

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -35,14 +35,28 @@ class Admin
 
     def create
       @category = Category.new(category_params)
+      @ancestry = category_params[:ancestry]
       authorize @category
 
       if @category.save
         redirect_to admin_categories_path,
                     notice: "Category '#{@category.name}' was successfully created."
       else
+        if @ancestry.present?
+          @parent_category = Category.find_by(id: @ancestry)
+        end
         render :new
       end
+    end
+
+    def destroy
+      @category = Category.find(params[:id])
+      authorize @category
+      name = @category.name
+      @category.destroy
+
+      redirect_to admin_categories_path,
+                    notice: "Category '#{name}' was successfully deleted."
     end
 
     private

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -34,7 +34,7 @@ class Admin
     end
 
     def create
-      @category = Category.new(name: category_params["name"], ancestry: category_params["ancestry"])
+      @category = Category.new(category_params)
       authorize @category
 
       if @category.save

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -18,7 +18,7 @@ class Admin
       @category = Category.find(params[:id])
       authorize @category
 
-      if @category.update(name: category_params["name"])
+      if @category.update(category_params)
         redirect_to admin_categories_path, notice: 'Category was successfully updated.'
       else
         render :edit

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -17,9 +17,8 @@ class Admin
     def update
       @category = Category.find(params[:id])
       authorize @category
-      permitted_params = params.require(:category).permit(:name)
 
-      if @category.update(name: permitted_params["name"])
+      if @category.update(name: category_params["name"])
         redirect_to admin_categories_path, notice: 'Category was successfully updated.'
       else
         render :edit
@@ -35,9 +34,7 @@ class Admin
     end
 
     def create
-      permitted_params = params.require(:category).permit(:name, :ancestry)
-
-      @category = Category.new(name: permitted_params["name"], ancestry: permitted_params["ancestry"])
+      @category = Category.new(name: category_params["name"], ancestry: category_params["ancestry"])
       authorize @category
 
       if @category.save
@@ -56,6 +53,10 @@ class Admin
         subcategories = categories.select{ |c| c.parent_id == parent_category.id   }
         { parent_category: parent_category, subcategories: subcategories }
       }
+    end
+
+    def category_params
+      params.require(:category).permit(:name, :ancestry)
     end
   end
 end

--- a/app/views/admin/categories/_category_list_element.html.haml
+++ b/app/views/admin/categories/_category_list_element.html.haml
@@ -5,11 +5,9 @@
     %i.fa.fa-chevron-right
     %span
       = parent_category.name
-  %div.tag_list_element_actions_container
+  %div
     %span
-      = link_to fa_icon("edit"), edit_admin_category_path(parent_category.id), class: "tag_edit_icon"
-    %span
-      = link_to fa_icon("trash"), admin_category_path(parent_category.id), method: :delete, data: { confirm: "Are you sure to delete #{parent_category.name} category?" }, class: "tag_delete_icon"
+      = link_to fa_icon("edit"), edit_admin_category_path(parent_category.id), class: "category_edit_icon"
   %div{style: "clear: both;"} 
 %div.subcategories_container.hide{ id: "category_#{parent_category.id}_subcategories"}  
   - subcategories.each do |subcategory| 
@@ -17,6 +15,4 @@
   %div.mt-15
     = link_to " + Add New #{parent_category.name} Subcategory".html_safe, new_admin_category_path(ancestry: parent_category.id), class: 'btn btn-primary'
   %div{style: "clear: both;"}        
-
-
 

--- a/app/views/admin/categories/_category_list_element.html.haml
+++ b/app/views/admin/categories/_category_list_element.html.haml
@@ -11,10 +11,12 @@
     %span
       = link_to fa_icon("trash"), admin_category_path(parent_category.id), method: :delete, data: { confirm: "Are you sure to delete #{parent_category.name} category?" }, class: "tag_delete_icon"
   %div{style: "clear: both;"} 
-- if subcategories.present?
-  %div.subcategories_container.hide{ id: "category_#{parent_category.id}_subcategories"}  
-    - subcategories.each do |subcategory| 
-      = render "subcategory_list_element", category: subcategory
+%div.subcategories_container.hide{ id: "category_#{parent_category.id}_subcategories"}  
+  - subcategories.each do |subcategory| 
+    = render "subcategory_list_element", category: subcategory
+  %div.mt-15
+    = link_to " + Add New #{parent_category.name} Subcategory".html_safe, new_admin_category_path(ancestry: parent_category.id), class: 'btn btn-primary'
+  %div{style: "clear: both;"}        
 
 
 

--- a/app/views/admin/categories/_form.html.haml
+++ b/app/views/admin/categories/_form.html.haml
@@ -2,6 +2,9 @@
 = f.label :name
 = f.text_field :name, required: true, maxlength: 50, class: 'form-control'
 
+- if @parent_category
+  = f.hidden_field :ancestry, value: parent_category.id
+
 %div.tag_form_buttons_container
   = f.submit 'Save', class: 'btn btn-primary'
   = link_to 'Back', admin_categories_path, class: 'btn btn-primary'

--- a/app/views/admin/categories/_subcategory_list_element.html.haml
+++ b/app/views/admin/categories/_subcategory_list_element.html.haml
@@ -6,5 +6,5 @@
     %span
       = link_to fa_icon("edit"), edit_admin_category_path(category.id), class: "tag_edit_icon"
     %span
-      = link_to fa_icon("trash"), admin_category_path(category.id), method: :delete, data: { confirm: "Are you sure to delete #{category} category?" }, class: "tag_delete_icon"
+      = link_to fa_icon("trash"), admin_category_path(category.id), method: :delete, data: { turbolinks: false, confirm: "Are you sure you want to delete the #{category.name} subcategory? It is associated with #{category.resource_count} services. This action cannot be undone." }, class: "tag_delete_icon"
   %div{style: "clear: both;"} 

--- a/app/views/admin/categories/_subcategory_list_element.html.haml
+++ b/app/views/admin/categories/_subcategory_list_element.html.haml
@@ -6,5 +6,5 @@
     %span
       = link_to fa_icon("edit"), edit_admin_category_path(category.id), class: "tag_edit_icon"
     %span
-      = link_to fa_icon("trash"), admin_category_path(category.id), method: :delete, data: { turbolinks: false, confirm: "Are you sure you want to delete the #{category.name} subcategory? It is associated with #{category.resource_count} services. This action cannot be undone." }, class: "tag_delete_icon"
+      = link_to fa_icon("trash"), admin_category_path(category.id), method: :delete, id: "category-#{category.id}-delete", data: { turbolinks: false, confirm: "Are you sure you want to delete the #{category.name} subcategory? It is associated with #{category.resource_count} services. This action cannot be undone." }, class: "tag_delete_icon"
   %div{style: "clear: both;"} 

--- a/app/views/admin/categories/new.html.haml
+++ b/app/views/admin/categories/new.html.haml
@@ -5,5 +5,7 @@
   <h1>New Category</h1>
 = render 'error_messages', category: @category
 
+%p New categories will not appear in search filters until they have been assigned to at least one service. 
+
 = form_for [:admin, @category], url: admin_categories_path, html: { method: :post } do |f| 
   = render 'form', f: f, parent_category: @parent_category

--- a/app/views/admin/categories/new.html.haml
+++ b/app/views/admin/categories/new.html.haml
@@ -1,5 +1,9 @@
-<h1>New Category</h1>
+
+- if @parent_category.present?
+  <h1>New #{@parent_category.name} Subcategory</h1>
+- else
+  <h1>New Category</h1>
 = render 'error_messages', category: @category
 
 = form_for [:admin, @category], url: admin_categories_path, html: { method: :post } do |f| 
-  = render 'form', f: f
+  = render 'form', f: f, parent_category: @parent_category

--- a/app/views/admin/services/forms/_categories.html.haml
+++ b/app/views/admin/services/forms/_categories.html.haml
@@ -9,4 +9,4 @@
   = field_set_tag nil, id: 'categories' do
     = f.label :services
     = categories_expand_button
-    = nested_categories(Category.unarchived.arrange(order: :name))
+    = nested_categories(Category.all.arrange(order: :name))

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -4,7 +4,6 @@
     = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_MAPS_UI_API_KEY']}"
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'admin/application', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application_pack', 'data-turbolinks-track': 'reload'
     %meta{ content: 'width=device-width, initial-scale=1.0', name: 'viewport' }
     %title= content_for?(:title) ? yield(:title) : t('titles.admin', brand: t('titles.brand'))
     %meta{ content: content_for?(:description) ? yield(:description) : "Admin Interface for #{t('titles.brand')}", name: 'description' }

--- a/spec/features/admin/categories/create_category_spec.rb
+++ b/spec/features/admin/categories/create_category_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Update name' do
+feature 'Create Category' do
   background do
     @category = create(:category)
     login_super_admin

--- a/spec/features/admin/categories/create_subcategory_spec.rb
+++ b/spec/features/admin/categories/create_subcategory_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+feature 'Create Subcategory' do
+  background do
+    @category = create(:jobs)
+    login_super_admin
+    visit '/admin/categories'
+  end
+
+  scenario 'with valid name' do
+    click_link "Add New Jobs Subcategory"
+    expect(page).to have_content "New Jobs Subcategory"
+    fill_in 'category_name', with: 'Jobs Subcategory'
+    click_button 'Save'
+    expect(page).to have_content "Category 'Jobs Subcategory' was successfully created."
+  end
+end

--- a/spec/features/admin/categories/delete_subcategory_spec.rb
+++ b/spec/features/admin/categories/delete_subcategory_spec.rb
@@ -9,9 +9,18 @@ feature 'Delete Subcategory' do
   end
 
   scenario 'delete subcategory', js: true do
+    # click_on "Expand All"
+    find_by_id("expand_all").click
+    # click(id: "category-#{@jobs_subcategory.id}-delete")
     accept_confirm do
-        click_link(href: "/admin/categories/#{@jobs_subcategory.id}")
+      find_by_id("category-#{@jobs_subcategory.id}-delete").click
     end
+
+    # This extra accept_confirm is required because of a bug
+    # Confirm dialog appears twice throughout the app 
+    # This is a known issue and will be fixed in the future
+    accept_confirm
+
     expect(page).to have_content "Category '#{@jobs_subcategory.name}' was successfully deleted."
   end
 end

--- a/spec/features/admin/categories/delete_subcategory_spec.rb
+++ b/spec/features/admin/categories/delete_subcategory_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+feature 'Delete Subcategory' do
+  background do
+    @jobs_category = create(:jobs)
+    @jobs_subcategory = create(:category, ancestry: @jobs_category.id)
+    login_super_admin
+    visit '/admin/categories'
+  end
+
+  scenario 'delete subcategory', js: true do
+    expect(page).to have_content @jobs_subcategory.name
+    accept_confirm do
+        click_link(href: "/admin/categories/#{@jobs_subcategory.id}")
+    end
+    expect(page).to have_content "Category '#{@jobs_subcategory.name}' was successfully deleted."
+    expect(page).not_to have_content @jobs_subcategory.name
+  end
+end

--- a/spec/features/admin/categories/delete_subcategory_spec.rb
+++ b/spec/features/admin/categories/delete_subcategory_spec.rb
@@ -16,11 +16,6 @@ feature 'Delete Subcategory' do
       find_by_id("category-#{@jobs_subcategory.id}-delete").click
     end
 
-    # This extra accept_confirm is required because of a bug
-    # Confirm dialog appears twice throughout the app 
-    # This is a known issue and will be fixed in the future
-    accept_confirm
-
     expect(page).to have_content "Category '#{@jobs_subcategory.name}' was successfully deleted."
   end
 end

--- a/spec/features/admin/categories/delete_subcategory_spec.rb
+++ b/spec/features/admin/categories/delete_subcategory_spec.rb
@@ -9,9 +9,7 @@ feature 'Delete Subcategory' do
   end
 
   scenario 'delete subcategory', js: true do
-    # click_on "Expand All"
     find_by_id("expand_all").click
-    # click(id: "category-#{@jobs_subcategory.id}-delete")
     accept_confirm do
       find_by_id("category-#{@jobs_subcategory.id}-delete").click
     end

--- a/spec/features/admin/categories/delete_subcategory_spec.rb
+++ b/spec/features/admin/categories/delete_subcategory_spec.rb
@@ -9,11 +9,9 @@ feature 'Delete Subcategory' do
   end
 
   scenario 'delete subcategory', js: true do
-    expect(page).to have_content @jobs_subcategory.name
     accept_confirm do
         click_link(href: "/admin/categories/#{@jobs_subcategory.id}")
     end
     expect(page).to have_content "Category '#{@jobs_subcategory.name}' was successfully deleted."
-    expect(page).not_to have_content @jobs_subcategory.name
   end
 end


### PR DESCRIPTION
## Description
Allows super admins to delete subcategories from the admin category manager. 

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-130](https://app.clickup.com/t/9006094761/BCHDCC-130)

## Tests to Run
- `spec/features/admin/categories/delete_subcategory_spec.rb`


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ ] My code follows the code style of this project (https://rubystyle.guide/).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

