### PR TITLE
[BCHDCC-126/127] Strip Whitespace from Categories Before Save

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,6 +7,7 @@ class Category < ApplicationRecord
 
   validates :name, presence: { message: I18n.t('errors.messages.blank_for_category') }
   validates :name, uniqueness: true
+  before_validation :strip_whitespace
 
   validates :taxonomy_id,
             uniqueness: {
@@ -25,5 +26,11 @@ class Category < ApplicationRecord
 
   def resource_count
     services.count
+  end
+
+  private
+
+  def strip_whitespace
+    self.name = name.strip if name.present?
   end
 end


### PR DESCRIPTION
## Description
This is in response to QA feedback from Dale for both editing and adding new categories. 

Previously a category with leading whitespace would be saved even if all of the text matched an existing category. 

Now we strip the whitespace from categories before attempting to save. 

## Motivation and Context
Comments on the clickup ticket: https://app.clickup.com/t/9006094761/BCHDCC-126


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ x] My code follows the code style of this project (https://rubystyle.guide/).
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

