### PR TITLE
[BCHDCC-142] Login Bug 

### DIFF
--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,6 +1,6 @@
 - title "Resend Confirmation Instructions"
 .authform
-  = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, role: 'form' }) do |f|
+  = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, data: { turbo: false }, role: 'form' }) do |f|
     %h3 Resend confirmation instructions
     = render 'devise/shared/error_messages', resource: resource
     .form-group

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,6 +1,6 @@
 - title "Change Your Password"
 .authform
-  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, role: 'form' }) do |f|
+  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, data: { turbo: false }, role: 'form' }) do |f|
     %h3 Change your password
     = render 'devise/shared/error_messages', resource: resource
     = f.hidden_field :reset_password_token

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,7 +1,7 @@
 - title "Forgot Your Password"
 .authform.devise
   = content_tag(:span, nil, class: 'fa fa-key fa-3x', style: "display: block; text-align: center;")  
-  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, role: 'form', class: 'password-reset-form' }) do |f|
+  = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, data: { turbo: false }, role: 'form', class: 'password-reset-form' }) do |f|
     %h2.forgot-password-title Forgot your password?
     %h3.instructions Enter your email and we will send you instructions to reset your password.
     = render 'devise/shared/error_messages', resource: resource

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -5,7 +5,7 @@
 .edit-registration-container
   %h3
     Edit #{resource_name.to_s.humanize}
-  = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, role: 'form' }) do |f|
+  = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, data: { turbo: false }, role: 'form' }) do |f|
     = render 'devise/shared/error_messages', resource: resource
     .form-group
       - if current_admin&.super_admin?

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -3,7 +3,7 @@
   - if resource.class.name == User.name
     = content_tag(:span, nil, class: 'fa fa-key fa-3x', style: "display: block", "aria-hidden": "true")
 
-  = form_for(resource, as: resource_name, url: session_path(resource_name), html: { role: 'form', class: 'form' }) do |f|
+  = form_for(resource, as: resource_name, url: session_path(resource_name), html: { data: { turbo: false }, role: 'form', class: 'form' }) do |f|
     %h2 Login
     .form-group
       = f.label :email

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -28,7 +28,7 @@
               %a{ href: edit_user_registration_path, aria: { label: t('navigation.account_details') } }
                 = t('navigation.account_details')
             %li
-              = link_to t('navigation.sign_out'), destroy_user_session_path, method: 'delete', aria: { label: t('navigation.sign_out') }
+              = link_to t('navigation.sign_out'), destroy_user_session_path, data: { turbo_method: :delete }, aria: { label: t('navigation.sign_out') }
       - else
         %li
           %a.popup-trigger.popup-account#user-btn{ href: new_user_session_path, aria: { label: t('users.login') } }
@@ -63,7 +63,7 @@
           %a{ href: edit_user_registration_path, aria: { label: t('navigation.account_details') } }
             = t('navigation.account_details')
         %li
-          = link_to t('navigation.sign_out'), destroy_user_session_path, method: 'delete', aria: { label: t('navigation.sign_out') }
+          = link_to t('navigation.sign_out'), destroy_user_session_path, data: { turbo_method: :delete }, aria: { label: t('navigation.sign_out') }
       - else
         %li
           %a{ href: new_user_session_path, aria: { label: t('navigation.sign_in') } }

--- a/app/views/shared/_navigation_links.html.haml
+++ b/app/views/shared/_navigation_links.html.haml
@@ -2,7 +2,7 @@
   %li
     = link_to t('navigation.edit_account'), edit_user_registration_path
   %li
-    = link_to t('navigation.sign_out'), destroy_user_session_path, method: 'delete'
+    = link_to t('navigation.sign_out'), destroy_user_session_path, data: { turbo_method: :delete }
   %ul.nav.navbar-nav.navbar-right
     %li
       = link_to "Hi, #{current_user.name}", '#', class: 'logged-in'


### PR DESCRIPTION
## Description
This was an oversight during the migration from Turbolinks to Turbo. 

Adds 'turbo-method: delete' to public log out links.

Opts devise forms out of using Turbo due to a known conflict between the two. 


## Internal Checklist
<!--- Go over all the following points and make sure you feel comfortable you covered them. -->
- [ x] My code follows the code style of this project (https://rubystyle.guide/).
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

