### PR TITLE
[BCHDCC-152] Vertical Pagination Bug

### DIFF
--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -19,7 +19,7 @@
 
 @import 'variables';
 @import "components/*";
-@import "components/*";
+@import "../components/pagination";
 @import "font-awesome";
 
 


### PR DESCRIPTION
## Description
Pagination on the admin side was looking bad and stacking vertically. Turns out this is because the admin side's scss file wasn't pulling in the pagination styles from `app/assets/stylesheets/components/_pagination.scss`. This is a one line change which pulls in those pagination styles and makes the buttons render like so: 

services page:
<img width="832" height="313" alt="Screenshot 2026-06-03 at 1 58 28 PM" src="https://github.com/user-attachments/assets/69662146-f15e-42ec-99ce-27450b1cc080" />

locations page:
<img width="790" height="444" alt="Screenshot 2026-06-03 at 1 59 12 PM" src="https://github.com/user-attachments/assets/7934cf06-91dc-4e58-9a25-e7e39fa669e6" />


## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-152](https://app.clickup.com/t/9006094761/BCHDCC-152) 


