### PR TITLE
[BCHDCC-151] Admin Logo Bug

### DIFF
--- a/app/assets/stylesheets/admin/components/footer.scss
+++ b/app/assets/stylesheets/admin/components/footer.scss
@@ -1,6 +1,6 @@
 .footer {
   position: relative;
-  padding: 20px;
+  padding: 50px 20px 20px;
 
   &::before {
     content: '';


### PR DESCRIPTION
## Description
The footer logo on the admin side was being bisected by a horizontal line. This adds some padding to the footer content to position it below the line. 

<img width="1053" height="435" alt="Screenshot 2026-06-03 at 2 27 03 PM" src="https://github.com/user-attachments/assets/59a57b94-a2b6-40c0-91bc-f8cb20e8e5b3" />


## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-151](https://app.clickup.com/t/9006094761/BCHDCC-151) - TICKET TITLE

