### PR TITLE
[BCHDCC-144, BCHDCC-150] Add Locations to Cart

### DIFF
--- a/app/assets/stylesheets/components/_add_to_cart_button.scss
+++ b/app/assets/stylesheets/components/_add_to_cart_button.scss
@@ -60,6 +60,9 @@
   // badge), then nudge it down to sit alongside the large 3em title text.
   align-self: flex-start;
   margin-top: .75rem;
+  // Keep the button at its natural size so a long title shrinks the hgroup
+  // instead of bumping the button onto the next line.
+  flex-shrink: 0;
   gap: .4em;
   color: $greyscale_dark;
   font-size: .8rem;
@@ -80,9 +83,16 @@
 }
 
 // Lay the show-page header out as a row so the button sits beside the title.
+// `nowrap` keeps the button on the title's line even when the title is long;
+// the hgroup (below) is allowed to shrink and wrap its text instead.
 #detail-info .details-content > header {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: .75em;
+
+  // Let the title block shrink so long names wrap rather than pushing the button down.
+  > hgroup {
+    min-width: 0;
+  }
 }

--- a/app/assets/stylesheets/components/_add_to_cart_button.scss
+++ b/app/assets/stylesheets/components/_add_to_cart_button.scss
@@ -1,0 +1,88 @@
+// Toggle button for adding a location to the PDF "cart".
+// Used on the locations index results list (icon-only, top-right of each entry)
+// and on the show page (an "Add to PDF" label button beside the title).
+// The `.is-selected` state is toggled by app/javascript/app/cart/pdf-cart.js.
+.add-to-cart {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: $font_sans_serif;
+  color: $greyscale_dark;
+
+  &__icon {
+    line-height: 1;
+  }
+
+  // The green check shown once a location has been added; hidden by default.
+  &__icon--added {
+    display: none;
+    color: $green;
+  }
+
+  // Selected state: hide the "add" affordance, reveal the green check.
+  &.is-selected {
+    .add-to-cart__icon--add,
+    .add-to-cart__label {
+      display: none;
+    }
+
+    .add-to-cart__icon--added {
+      display: inline-block;
+    }
+  }
+}
+
+// Establish a positioning context so the index button can pin to the top-right.
+.results-entry {
+  position: relative;
+}
+
+// Index results: an icon-only button in the top-right corner of each result entry.
+// Scoped under `.results-entry` to outrank the global `.main * { position: relative }`
+// reset (in _base.scss), which would otherwise keep this button in normal flow.
+.results-entry .add-to-cart--index {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  z-index: 1;
+
+  .add-to-cart__icon {
+    font-size: 1.5rem;
+  }
+}
+
+// Show page: an inline "Add to PDF" button next to the location title.
+.add-to-cart--detail {
+  display: inline-flex;
+  align-items: center;
+  // Align only this button to the top of the header (without affecting the featured
+  // badge), then nudge it down to sit alongside the large 3em title text.
+  align-self: flex-start;
+  margin-top: .75rem;
+  gap: .4em;
+  color: $greyscale_dark;
+  font-size: .8rem;
+  font-weight: bold;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+
+  .add-to-cart__icon--add {
+    border: 1px solid currentColor;
+    border-radius: $border-radius-base;
+    padding: .1em;
+    font-size: .9rem;
+  }
+
+  .add-to-cart__icon--added {
+    font-size: 1.6rem;
+  }
+}
+
+// Lay the show-page header out as a row so the button sits beside the title.
+#detail-info .details-content > header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: .75em;
+}

--- a/app/javascript/app/cart/pdf-cart.js
+++ b/app/javascript/app/cart/pdf-cart.js
@@ -1,0 +1,97 @@
+// Manages the "Add to PDF" cart: the set of selected location IDs, persisted in a
+// cookie so the selection survives navigation between the locations index and show pages.
+// Selection logic for the cart banner count and every `.add-to-cart` toggle button lives here.
+import cookie from '../util/cookie';
+
+const COOKIE_NAME = 'pdf_cart';
+// Days until the cart cookie expires (keeps a selection across short browsing sessions).
+const COOKIE_DAYS = 1;
+
+// Read the selected location IDs (as strings) from the cookie.
+// @return [Array<String>] The selected location IDs, or an empty array.
+function _read() {
+  const raw = cookie.read(COOKIE_NAME);
+  if (!raw) { return []; }
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw));
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+// Persist the selected location IDs to the cookie.
+// @param ids [Array<String>] The selected location IDs.
+function _write(ids) {
+  cookie.create(COOKIE_NAME, encodeURIComponent(JSON.stringify(ids)), false, COOKIE_DAYS);
+}
+
+// Reflect a single button's selected/unselected state in the DOM.
+// @param button [Element] The `.add-to-cart` button.
+// @param selected [Boolean] Whether its location is in the cart.
+function _setButtonState(button, selected) {
+  button.classList.toggle('is-selected', selected);
+  button.setAttribute('aria-pressed', selected ? 'true' : 'false');
+
+  const name = button.dataset.locationName || 'this listing';
+  button.setAttribute('aria-label', selected ? `Remove ${name} from PDF` : `Add ${name} to PDF`);
+}
+
+// Reflect the current selection across the page: each cart banner's count/preview
+// button and every add-to-cart toggle. Safe to call when no cart elements exist.
+function sync() {
+  const ids = _read();
+
+  document.querySelectorAll('.cart-banner').forEach((banner) => {
+    const count = banner.querySelector('.cart-banner__count');
+    if (count) { count.textContent = ids.length; }
+
+    const preview = banner.querySelector('.cart-banner__preview');
+    if (preview) { preview.disabled = ids.length === 0; }
+  });
+
+  document.querySelectorAll('.add-to-cart').forEach((button) => {
+    _setButtonState(button, ids.indexOf(String(button.dataset.locationId)) !== -1);
+  });
+}
+
+// Toggle a location in/out of the cart when its button is clicked.
+// Uses event delegation so buttons added later (e.g. after an AJAX filter) still work.
+function _onClick(e) {
+  const button = e.target.closest('.add-to-cart');
+  if (!button) { return; }
+
+  e.preventDefault();
+
+  const id = String(button.dataset.locationId);
+  let ids = _read();
+
+  if (ids.indexOf(id) !== -1) {
+    ids = ids.filter((existing) => existing !== id);
+  } else {
+    ids.push(id);
+  }
+
+  _write(ids);
+  sync();
+}
+
+// Whether the delegated click listener has been attached. The module persists across
+// Turbo navigations, so we only ever bind once.
+let _bound = false;
+
+// Wire up the cart: attach the (one-time) click listener and sync the current state.
+function init() {
+  if (!_bound) {
+    document.addEventListener('click', _onClick);
+    _bound = true;
+  }
+
+  sync();
+}
+
+export default {
+  init: init,
+  sync: sync
+};

--- a/app/javascript/app/cart/pdf-cart.js
+++ b/app/javascript/app/cart/pdf-cart.js
@@ -47,6 +47,11 @@ function sync() {
     const count = banner.querySelector('.cart-banner__count');
     if (count) { count.textContent = ids.length; }
 
+    const label = banner.querySelector('.cart-banner__label');
+    if (label) {
+      label.textContent = ids.length === 1 ? label.dataset.one : label.dataset.other;
+    }
+
     const preview = banner.querySelector('.cart-banner__preview');
     if (preview) { preview.disabled = ids.length === 0; }
   });

--- a/app/javascript/app/search/filter/search-filters.js
+++ b/app/javascript/app/search/filter/search-filters.js
@@ -1,6 +1,7 @@
 // Handles search filter functionality.
 import TextInput from './TextInput';
 import map from '../../result/result-map';
+import cart from '../../cart/pdf-cart';
 import { initializeMapToggle } from '../../util/map/map_toggle';
 
 // The search filters.
@@ -210,6 +211,9 @@ function _getSearchResults(e){
         if ( $("#map-view").length ){
           map.init();
         }
+
+        // Re-apply the cart selection state to the freshly rendered result buttons.
+        cart.sync();
 
         //remove layout=false from pagination hrefs
         $('nav a').each(function(){

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -15,6 +15,7 @@ import filters from './app/search/filter/search-filters';
 import map from './app/result/result-map';
 import detailmap from './app/detail/detail-map';
 import header from './app/search/header';
+import cart from './app/cart/pdf-cart';
 import cl from './app/detail/character-limited/character-limiter';
 import utilityLinks from './app/detail/utility-links';
 import "@hotwired/turbo-rails"
@@ -53,6 +54,7 @@ document.addEventListener('turbo:load', () => {
     filters.init();
     map.init();
     header.init();
+    cart.init();
   }
 
 
@@ -64,6 +66,7 @@ document.addEventListener('turbo:load', () => {
     header.init();
     utilityLinks.init();
     filters.init();
+    cart.init();
   }
 
   // Hamburger menu toggle functionality

--- a/app/views/component/locations/_add_to_cart_button.html.haml
+++ b/app/views/component/locations/_add_to_cart_button.html.haml
@@ -1,0 +1,10 @@
+-# Toggle button to add/remove a location from the "PDF cart".
+-# Shared by the locations index results list (icon-only) and the show page (with label).
+-# Selection state is driven client-side by app/javascript/app/cart/pdf-cart.js.
+-# Locals: location (required); variant (:index or :detail, default :index).
+- variant = local_assigns.fetch(:variant, :index)
+%button.add-to-cart{ class: "add-to-cart--#{variant}", type: 'button', data: { location_id: location.id, location_name: location.name }, aria: { pressed: 'false', label: "Add #{location.name} to PDF" } }
+  %i.add-to-cart__icon.add-to-cart__icon--add.fa.fa-plus{ aria: { hidden: 'true' } }
+  - if variant == :detail
+    %span.add-to-cart__label= t('cart_banner.add_to_pdf')
+  %i.add-to-cart__icon.add-to-cart__icon--added.fa.fa-check{ aria: { hidden: 'true' } }

--- a/app/views/component/locations/_cart_banner.html.haml
+++ b/app/views/component/locations/_cart_banner.html.haml
@@ -8,7 +8,7 @@
       %p.cart-banner__title= t('cart_banner.title')
       %p.cart-banner__status{ aria: { live: 'polite' } }
         %span.cart-banner__count= count
-        = t('cart_banner.listings_selected', count: count)
+        %span.cart-banner__label{ data: { one: t('cart_banner.listings_selected', count: 1), other: t('cart_banner.listings_selected', count: 2) } }= t('cart_banner.listings_selected', count: count)
     %div.cart-banner__actions
       %button.cart-banner__preview#cart-banner-preview{ type: 'button', disabled: count.zero? }
         %span= t('cart_banner.preview')

--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -17,7 +17,7 @@
             = link_to locations_path(org_name: location.organization.name), role: "link", aria: { label: "View all locations for #{superscript_ordinals(location.organization.name)}" } do
               = superscript_ordinals(location.organization.name)
 
-
+      = render 'component/locations/add_to_cart_button', location: location, variant: :detail
 
     %section.overview-box
       = render 'component/detail/location_short_desc', location: location

--- a/app/views/component/locations/results/_list_view.html.haml
+++ b/app/views/component/locations/results/_list_view.html.haml
@@ -7,6 +7,7 @@
 
       %li{class: cycle('search-result-blue', 'search-result-white')}
         %section.results-entry{ itemscope: '', itemtype: 'http://schema.org/Organization' }
+          = render 'component/locations/add_to_cart_button', location: location, variant: :index
           %header
             - if location.featured
               = render 'component/locations/results/featured_location'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -493,6 +493,7 @@ en:
       one: 'listing selected'
       other: 'listings selected'
     preview: 'Preview'
+    add_to_pdf: 'Add to PDF'
   branding:
     description: >
       Retrieve detailed information about the services available


### PR DESCRIPTION
## Description
- creates a new button which adds a location to the banner cart
- it does so by storing selected locations in cookies 
- the data in the cookies will be accessable client are server side for later tickets
- the number of selected locations is reflected in the banner
- available on both the locations search results page and the individual location details pages
- pdf preview button becomes enabled when there are locations selected 

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-144](https://app.clickup.com/t/9006094761/BCHDCC-144) 
[BCHDCC-150](https://app.clickup.com/t/9006094761/BCHDCC-150) 


## Screenshots
<img width="1447" height="697" alt="Screenshot 2026-06-09 at 2 28 56 PM" src="https://github.com/user-attachments/assets/63ab84b2-1b4c-4541-b7e4-3db44542414a" />

<img width="1186" height="658" alt="Screenshot 2026-06-09 at 2 29 16 PM" src="https://github.com/user-attachments/assets/6c167926-2f33-47b4-b2b6-28a50ae85874" />

<img width="1454" height="576" alt="Screenshot 2026-06-09 at 2 29 57 PM" src="https://github.com/user-attachments/assets/ad73e9dc-5a8a-46c0-b0b0-bfc1c351bd64" />
<img width="1452" height="681" alt="Screenshot 2026-06-09 at 2 30 09 PM" src="https://github.com/user-attachments/assets/3dfa80ed-355a-454b-8318-65101fa3cdb6" />

