### PR TITLE
[BCHDCC-145, BCHDCC-146] Preview Cart Page

### DIFF
--- a/app/assets/stylesheets/components/_add_to_cart_button.scss
+++ b/app/assets/stylesheets/components/_add_to_cart_button.scss
@@ -1,0 +1,88 @@
+// Toggle button for adding a location to the PDF "cart".
+// Used on the locations index results list (icon-only, top-right of each entry)
+// and on the show page (an "Add to PDF" label button beside the title).
+// The `.is-selected` state is toggled by app/javascript/app/cart/pdf-cart.js.
+.add-to-cart {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: $font_sans_serif;
+  color: $greyscale_dark;
+
+  &__icon {
+    line-height: 1;
+  }
+
+  // The green check shown once a location has been added; hidden by default.
+  &__icon--added {
+    display: none;
+    color: $green;
+  }
+
+  // Selected state: hide the "add" affordance, reveal the green check.
+  &.is-selected {
+    .add-to-cart__icon--add,
+    .add-to-cart__label {
+      display: none;
+    }
+
+    .add-to-cart__icon--added {
+      display: inline-block;
+    }
+  }
+}
+
+// Establish a positioning context so the index button can pin to the top-right.
+.results-entry {
+  position: relative;
+}
+
+// Index results: an icon-only button in the top-right corner of each result entry.
+// Scoped under `.results-entry` to outrank the global `.main * { position: relative }`
+// reset (in _base.scss), which would otherwise keep this button in normal flow.
+.results-entry .add-to-cart--index {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  z-index: 1;
+
+  .add-to-cart__icon {
+    font-size: 1.5rem;
+  }
+}
+
+// Show page: an inline "Add to PDF" button next to the location title.
+.add-to-cart--detail {
+  display: inline-flex;
+  align-items: center;
+  // Align only this button to the top of the header (without affecting the featured
+  // badge), then nudge it down to sit alongside the large 3em title text.
+  align-self: flex-start;
+  margin-top: .75rem;
+  gap: .4em;
+  color: $greyscale_dark;
+  font-size: .8rem;
+  font-weight: bold;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+
+  .add-to-cart__icon--add {
+    border: 1px solid currentColor;
+    border-radius: $border-radius-base;
+    padding: .1em;
+    font-size: .9rem;
+  }
+
+  .add-to-cart__icon--added {
+    font-size: 1.6rem;
+  }
+}
+
+// Lay the show-page header out as a row so the button sits beside the title.
+#detail-info .details-content > header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: .75em;
+}

--- a/app/assets/stylesheets/components/_cart_preview.scss
+++ b/app/assets/stylesheets/components/_cart_preview.scss
@@ -1,0 +1,181 @@
+// Preview page for the listings selected via the "Add to PDF" cart (/cart/preview).
+.cart-preview {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5em;
+  font-family: $font_sans_serif;
+
+  // "< Go back" link above the heading.
+  &__back {
+    display: inline-flex;
+    align-items: center;
+    color: $purple;
+    text-decoration: none;
+    font-size: 1rem;
+
+    .fa {
+      margin-right: .5em;
+    }
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  &__heading {
+    margin: .5em 0 1em;
+    color: $greyscale_dark;
+    font-weight: bold;
+    font-size: 2rem;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border: 1px solid rgba($black, .1);
+    border-radius: $border-radius-base;
+    overflow: hidden;
+  }
+
+  // Alternating row backgrounds, mirroring the search results list.
+  &__item {
+    &--blue {
+      background: mix(white, $blue, 90);
+    }
+
+    &--white {
+      background: $white;
+    }
+  }
+
+  // Centered confirmation + download call to action below the list.
+  &__footer {
+    margin-top: 2.5em;
+    text-align: center;
+  }
+
+  &__confirm {
+    margin: 0;
+    color: $greyscale_dark;
+    font-weight: bold;
+    font-size: 1.25rem;
+  }
+
+  &__note {
+    margin: .25em 0 1.25em;
+    color: $greyscale_midtone;
+    font-size: .9rem;
+  }
+
+  // Outlined "Download PDF" button, styled like the banner's Preview button.
+  &__download {
+    background: transparent;
+    color: $blue;
+    border: 1px solid $blue;
+    border-radius: $border-radius-base;
+    padding: .6em 1.5em;
+    font-family: $font_sans_serif;
+    font-size: 1rem;
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+      background: $blue;
+      color: $white;
+    }
+  }
+
+  &__empty {
+    padding: 2em;
+    text-align: center;
+    color: $greyscale_midtone;
+  }
+}
+
+// A single selected listing within the preview list.
+.preview-card {
+  display: flex;
+  align-items: flex-start;
+  padding: 1.5em;
+
+  &__content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__name {
+    margin: 0;
+    font-size: 1.25rem;
+
+    a {
+      color: $purple;
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  &__phone {
+    margin: .25em 0 0;
+    color: $greyscale_dark;
+
+    a {
+      color: $greyscale_dark;
+    }
+  }
+
+  &__desc {
+    margin: 1em 0 0;
+    color: $greyscale_dark;
+
+    // Keep the preview compact: clamp the description to two lines.
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+
+    p {
+      margin: 0;
+    }
+  }
+
+  &__categories {
+    margin: .75em 0 0;
+    color: $greyscale_dark;
+    font-size: .95rem;
+  }
+
+  // Trash icon that removes the listing from the cart.
+  &__remove {
+    flex-shrink: 0;
+    margin-left: 1.5em;
+    background: transparent;
+    border: none;
+    color: $greyscale_midtone;
+    font-size: 1.1rem;
+    cursor: pointer;
+    padding: .25em;
+
+    &:hover,
+    &:focus {
+      color: $greyscale_dark;
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .cart-preview {
+    &__heading {
+      font-size: 1.5rem;
+    }
+  }
+
+  .preview-card {
+    padding: 1.25em;
+  }
+}

--- a/app/assets/stylesheets/components/_cart_preview.scss
+++ b/app/assets/stylesheets/components/_cart_preview.scss
@@ -1,4 +1,10 @@
 // Preview page for the listings selected via the "Add to PDF" cart (/cart/preview).
+
+.inside .main:has(.cart-preview) {
+  background-image: none;
+  background-color: $white;
+}
+
 .cart-preview {
   max-width: 1100px;
   margin: 0 auto;

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -1,0 +1,44 @@
+class CartController < ApplicationController
+  # Renders a preview of the listings the user selected via the "Add to PDF"
+  # cart before they download a PDF. The selection lives client-side in the
+  # `pdf_cart` cookie (see app/javascript/app/cart/pdf-cart.js); we read it here
+  # and load the matching locations, preserving the order they were added.
+  def preview
+    ids = selected_location_ids
+
+    locations = ids.present? ? load_locations(ids) : []
+    @locations = ids.map { |id| locations.find { |l| l.id.to_s == id } }.compact
+  end
+
+  private
+
+  # The selected location IDs from the cart cookie, as an array of strings.
+  # The cookie holds a JSON array of IDs, URL-encoded by the client; Rack
+  # usually decodes it for us, but we fall back to manual unescaping to be safe.
+  # Non-numeric values are dropped so they can never reach the query.
+  def selected_location_ids
+    raw = cookies[:pdf_cart]
+    return [] if raw.blank?
+
+    parsed = parse_cart_cookie(raw)
+    return [] unless parsed.is_a?(Array)
+
+    parsed.map(&:to_s).select { |id| id.match?(/\A\d+\z/) }
+  end
+
+  def parse_cart_cookie(raw)
+    JSON.parse(raw)
+  rescue JSON::ParserError
+    begin
+      JSON.parse(CGI.unescape(raw))
+    rescue JSON::ParserError
+      []
+    end
+  end
+
+  def load_locations(ids)
+    Location
+      .where(id: ids)
+      .includes(:organization, :phones, services: :categories)
+  end
+end

--- a/app/javascript/app/cart/cart-preview.js
+++ b/app/javascript/app/cart/cart-preview.js
@@ -1,0 +1,45 @@
+// Drives the cart preview page (/cart/preview): removing a listing from the
+// cart and reflecting an emptied cart in the UI. The listings themselves are
+// server-rendered; this only handles the interactive bits. Cart persistence
+// lives in app/javascript/app/cart/pdf-cart.js.
+import cart from './pdf-cart';
+
+// Remove the clicked listing from the cart cookie and from the page.
+function _onClick(e) {
+  const button = e.target.closest('.preview-card__remove');
+  if (!button) { return; }
+
+  cart.remove(button.dataset.locationId);
+
+  const item = button.closest('.cart-preview__item');
+  if (item) { item.remove(); }
+
+  _reflectEmptyState();
+}
+
+// Once the last listing is removed, swap the list/footer for the empty message.
+function _reflectEmptyState() {
+  const list = document.getElementById('cart-preview-list');
+  if (!list || list.querySelector('.cart-preview__item')) { return; }
+
+  list.hidden = true;
+
+  const footer = document.getElementById('cart-preview-footer');
+  if (footer) { footer.hidden = true; }
+
+  const empty = document.getElementById('cart-preview-empty');
+  if (empty) { empty.hidden = false; }
+}
+
+let _bound = false;
+
+function init() {
+  if (!_bound) {
+    document.addEventListener('click', _onClick);
+    _bound = true;
+  }
+}
+
+export default {
+  init: init
+};

--- a/app/javascript/app/cart/pdf-cart.js
+++ b/app/javascript/app/cart/pdf-cart.js
@@ -1,0 +1,97 @@
+// Manages the "Add to PDF" cart: the set of selected location IDs, persisted in a
+// cookie so the selection survives navigation between the locations index and show pages.
+// Selection logic for the cart banner count and every `.add-to-cart` toggle button lives here.
+import cookie from '../util/cookie';
+
+const COOKIE_NAME = 'pdf_cart';
+// Days until the cart cookie expires (keeps a selection across short browsing sessions).
+const COOKIE_DAYS = 1;
+
+// Read the selected location IDs (as strings) from the cookie.
+// @return [Array<String>] The selected location IDs, or an empty array.
+function _read() {
+  const raw = cookie.read(COOKIE_NAME);
+  if (!raw) { return []; }
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw));
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+// Persist the selected location IDs to the cookie.
+// @param ids [Array<String>] The selected location IDs.
+function _write(ids) {
+  cookie.create(COOKIE_NAME, encodeURIComponent(JSON.stringify(ids)), false, COOKIE_DAYS);
+}
+
+// Reflect a single button's selected/unselected state in the DOM.
+// @param button [Element] The `.add-to-cart` button.
+// @param selected [Boolean] Whether its location is in the cart.
+function _setButtonState(button, selected) {
+  button.classList.toggle('is-selected', selected);
+  button.setAttribute('aria-pressed', selected ? 'true' : 'false');
+
+  const name = button.dataset.locationName || 'this listing';
+  button.setAttribute('aria-label', selected ? `Remove ${name} from PDF` : `Add ${name} to PDF`);
+}
+
+// Reflect the current selection across the page: each cart banner's count/preview
+// button and every add-to-cart toggle. Safe to call when no cart elements exist.
+function sync() {
+  const ids = _read();
+
+  document.querySelectorAll('.cart-banner').forEach((banner) => {
+    const count = banner.querySelector('.cart-banner__count');
+    if (count) { count.textContent = ids.length; }
+
+    const preview = banner.querySelector('.cart-banner__preview');
+    if (preview) { preview.disabled = ids.length === 0; }
+  });
+
+  document.querySelectorAll('.add-to-cart').forEach((button) => {
+    _setButtonState(button, ids.indexOf(String(button.dataset.locationId)) !== -1);
+  });
+}
+
+// Toggle a location in/out of the cart when its button is clicked.
+// Uses event delegation so buttons added later (e.g. after an AJAX filter) still work.
+function _onClick(e) {
+  const button = e.target.closest('.add-to-cart');
+  if (!button) { return; }
+
+  e.preventDefault();
+
+  const id = String(button.dataset.locationId);
+  let ids = _read();
+
+  if (ids.indexOf(id) !== -1) {
+    ids = ids.filter((existing) => existing !== id);
+  } else {
+    ids.push(id);
+  }
+
+  _write(ids);
+  sync();
+}
+
+// Whether the delegated click listener has been attached. The module persists across
+// Turbo navigations, so we only ever bind once.
+let _bound = false;
+
+// Wire up the cart: attach the (one-time) click listener and sync the current state.
+function init() {
+  if (!_bound) {
+    document.addEventListener('click', _onClick);
+    _bound = true;
+  }
+
+  sync();
+}
+
+export default {
+  init: init,
+  sync: sync
+};

--- a/app/javascript/app/cart/pdf-cart.js
+++ b/app/javascript/app/cart/pdf-cart.js
@@ -56,6 +56,14 @@ function sync() {
   });
 }
 
+// Remove a single location from the cart and re-sync the UI.
+// @param id [String|Number] The location ID to remove.
+function remove(id) {
+  const target = String(id);
+  _write(_read().filter((existing) => existing !== target));
+  sync();
+}
+
 // Toggle a location in/out of the cart when its button is clicked.
 // Uses event delegation so buttons added later (e.g. after an AJAX filter) still work.
 function _onClick(e) {
@@ -81,6 +89,21 @@ function _onClick(e) {
 // Turbo navigations, so we only ever bind once.
 let _bound = false;
 
+// Send the user to the preview page when an enabled banner "Preview" button is
+// clicked. The banner is server-rendered and never swapped out, so a direct
+// listener fits (no delegation needed); the dataset guard keeps a repeat init()
+// on the same DOM from binding twice.
+function _bindPreview() {
+  document.querySelectorAll('.cart-banner__preview').forEach((button) => {
+    if (button.dataset.previewBound) { return; }
+    button.dataset.previewBound = 'true';
+
+    button.addEventListener('click', () => {
+      if (!button.disabled) { window.location.href = '/cart/preview'; }
+    });
+  });
+}
+
 // Wire up the cart: attach the (one-time) click listener and sync the current state.
 function init() {
   if (!_bound) {
@@ -88,10 +111,12 @@ function init() {
     _bound = true;
   }
 
+  _bindPreview();
   sync();
 }
 
 export default {
   init: init,
-  sync: sync
+  sync: sync,
+  remove: remove
 };

--- a/app/javascript/app/search/filter/search-filters.js
+++ b/app/javascript/app/search/filter/search-filters.js
@@ -1,6 +1,7 @@
 // Handles search filter functionality.
 import TextInput from './TextInput';
 import map from '../../result/result-map';
+import cart from '../../cart/pdf-cart';
 import { initializeMapToggle } from '../../util/map/map_toggle';
 
 // The search filters.
@@ -210,6 +211,9 @@ function _getSearchResults(e){
         if ( $("#map-view").length ){
           map.init();
         }
+
+        // Re-apply the cart selection state to the freshly rendered result buttons.
+        cart.sync();
 
         //remove layout=false from pagination hrefs
         $('nav a').each(function(){

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -16,6 +16,7 @@ import map from './app/result/result-map';
 import detailmap from './app/detail/detail-map';
 import header from './app/search/header';
 import cart from './app/cart/pdf-cart';
+import cartPreview from './app/cart/cart-preview';
 import cl from './app/detail/character-limited/character-limiter';
 import utilityLinks from './app/detail/utility-links';
 import "@hotwired/turbo-rails"
@@ -67,6 +68,12 @@ document.addEventListener('turbo:load', () => {
     utilityLinks.init();
     filters.init();
     cart.init();
+  }
+
+  // Cart Preview
+  const cartPreviewPage = document.getElementsByClassName('cart preview');
+  if (cartPreviewPage.length > 0) {
+    cartPreview.init();
   }
 
   // Hamburger menu toggle functionality

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -15,6 +15,7 @@ import filters from './app/search/filter/search-filters';
 import map from './app/result/result-map';
 import detailmap from './app/detail/detail-map';
 import header from './app/search/header';
+import cart from './app/cart/pdf-cart';
 import cl from './app/detail/character-limited/character-limiter';
 import utilityLinks from './app/detail/utility-links';
 import "@hotwired/turbo-rails"
@@ -53,6 +54,7 @@ document.addEventListener('turbo:load', () => {
     filters.init();
     map.init();
     header.init();
+    cart.init();
   }
 
 
@@ -64,6 +66,7 @@ document.addEventListener('turbo:load', () => {
     header.init();
     utilityLinks.init();
     filters.init();
+    cart.init();
   }
 
   // Hamburger menu toggle functionality

--- a/app/views/cart/preview.html.haml
+++ b/app/views/cart/preview.html.haml
@@ -1,0 +1,25 @@
+- title t('cart_preview.title')
+
+- content_for :breadcrumbs do
+  = link_to t('cart_preview.breadcrumb'), locations_path
+
+%div.cart-preview
+  = link_to locations_path, class: 'cart-preview__back' do
+    %i.fa.fa-chevron-left{ aria: { hidden: 'true' } }
+    %span= t('cart_preview.go_back')
+
+  %h1.cart-preview__heading= t('cart_preview.heading')
+
+  %ul.cart-preview__list#cart-preview-list{ hidden: @locations.empty? }
+    - @locations.each_with_index do |location, i|
+      %li.cart-preview__item{ class: cycle('cart-preview__item--blue', 'cart-preview__item--white'), data: { location_id: location.id } }
+        = render 'component/cart/preview_card', location: location
+
+  %div.cart-preview__empty#cart-preview-empty{ hidden: @locations.present? }
+    %p= t('cart_preview.empty')
+
+  %div.cart-preview__footer#cart-preview-footer{ hidden: @locations.empty? }
+    %p.cart-preview__confirm= t('cart_preview.confirm')
+    %p.cart-preview__note= t('cart_preview.note')
+    %button.cart-preview__download#cart-preview-download{ type: 'button' }
+      = t('cart_preview.download')

--- a/app/views/component/cart/_preview_card.html.haml
+++ b/app/views/component/cart/_preview_card.html.haml
@@ -1,0 +1,26 @@
+-# A single selected listing on the cart preview page (/cart/preview).
+-# Mirrors the key summary fields shown in the search results: name (linked),
+-# primary phone, short description and the categories its services belong to.
+-# The remove button drops the listing from the cart client-side
+-# (see app/javascript/app/cart/cart-preview.js).
+- categories = location.services.flat_map { |service| service.categories }.compact.map(&:name).uniq
+- phone = first_voice_or_hotline_phone_for(location.phones)
+%div.preview-card{ itemscope: '', itemtype: 'http://schema.org/Organization' }
+  %div.preview-card__content
+    %h2.preview-card__name
+      %a{ href: location_link_for(location) }
+        = superscript_ordinals(full_name_content_for(location))
+
+    - if phone.present?
+      %p.preview-card__phone
+        = render 'component/detail/phone', phone: phone, show_phone_type_and_department: false
+
+    - if location.short_desc.present?
+      %div.preview-card__desc
+        = render_markdown(location.short_desc)
+
+    - if categories.present?
+      %p.preview-card__categories= categories.join(', ')
+
+  %button.preview-card__remove{ type: 'button', data: { location_id: location.id, location_name: location.name }, aria: { label: "Remove #{location.name} from PDF" } }
+    %i.fa.fa-trash-o{ aria: { hidden: 'true' } }

--- a/app/views/component/locations/_add_to_cart_button.html.haml
+++ b/app/views/component/locations/_add_to_cart_button.html.haml
@@ -1,0 +1,10 @@
+-# Toggle button to add/remove a location from the "PDF cart".
+-# Shared by the locations index results list (icon-only) and the show page (with label).
+-# Selection state is driven client-side by app/javascript/app/cart/pdf-cart.js.
+-# Locals: location (required); variant (:index or :detail, default :index).
+- variant = local_assigns.fetch(:variant, :index)
+%button.add-to-cart{ class: "add-to-cart--#{variant}", type: 'button', data: { location_id: location.id, location_name: location.name }, aria: { pressed: 'false', label: "Add #{location.name} to PDF" } }
+  %i.add-to-cart__icon.add-to-cart__icon--add.fa.fa-plus{ aria: { hidden: 'true' } }
+  - if variant == :detail
+    %span.add-to-cart__label= t('cart_banner.add_to_pdf')
+  %i.add-to-cart__icon.add-to-cart__icon--added.fa.fa-check{ aria: { hidden: 'true' } }

--- a/app/views/component/locations/detail/_body.html.haml
+++ b/app/views/component/locations/detail/_body.html.haml
@@ -17,7 +17,7 @@
             = link_to locations_path(org_name: location.organization.name), role: "link", aria: { label: "View all locations for #{superscript_ordinals(location.organization.name)}" } do
               = superscript_ordinals(location.organization.name)
 
-
+      = render 'component/locations/add_to_cart_button', location: location, variant: :detail
 
     %section.overview-box
       = render 'component/detail/location_short_desc', location: location

--- a/app/views/component/locations/results/_list_view.html.haml
+++ b/app/views/component/locations/results/_list_view.html.haml
@@ -7,6 +7,7 @@
 
       %li{class: cycle('search-result-blue', 'search-result-white')}
         %section.results-entry{ itemscope: '', itemtype: 'http://schema.org/Organization' }
+          = render 'component/locations/add_to_cart_button', location: location, variant: :index
           %header
             - if location.featured
               = render 'component/locations/results/featured_location'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -494,6 +494,15 @@ en:
       other: 'listings selected'
     preview: 'Preview'
     add_to_pdf: 'Add to PDF'
+  cart_preview:
+    title: 'Preview your selected services'
+    heading: 'Preview your selected services'
+    breadcrumb: 'Community Resources'
+    go_back: 'Go back'
+    confirm: 'Does everything look good?'
+    note: 'Once downloaded, saved listings will be cleared'
+    download: 'Download PDF'
+    empty: "You haven't selected any listings yet."
   branding:
     description: >
       Retrieve detailed information about the services available

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -493,6 +493,7 @@ en:
       one: 'listing selected'
       other: 'listings selected'
     preview: 'Preview'
+    add_to_pdf: 'Add to PDF'
   branding:
     description: >
       Retrieve detailed information about the services available

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,11 @@ Rails.application.routes.draw do
   end
 
   get 'locations/*id/' => 'locations#show', as: 'location'
+
+  # Preview page for the listings selected via the "Add to PDF" cart
+  # (selection is persisted client-side in the `pdf_cart` cookie).
+  get '/cart/preview' => 'cart#preview', as: 'cart_preview'
+
   get '/about' => 'about#index'
   post '/feedback' => 'feedback#create'
   get '/feedback' => 'feedback#new'


### PR DESCRIPTION
## Description
- Adds a page for previewing selected locations
- Each location has a remove button
- Limits total selections to 50

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-145](https://app.clickup.com/t/9006094761/BCHDCC-145)
[BCHDCC-146](https://app.clickup.com/t/9006094761/BCHDCC-146)

## Screenshots
<!--- If this is a UI change, put a relevant screenshot(s) here with a 
      description of what is in it. -->
<img width="1443" height="714" alt="Screenshot 2026-06-12 at 11 03 10 AM" src="https://github.com/user-attachments/assets/61c83721-57b7-4906-9e42-2cded9c8d639" />
<img width="1435" height="754" alt="Screenshot 2026-06-12 at 11 03 26 AM" src="https://github.com/user-attachments/assets/5f6bbc94-ccdd-4712-9cad-41ca5804520a" />

