### PR TITLE
[BCHDCC-157] Limit Cart Selections to 50

### DIFF
--- a/app/assets/stylesheets/components/_cart_banner.scss
+++ b/app/assets/stylesheets/components/_cart_banner.scss
@@ -33,6 +33,13 @@
     font-size: 1rem;
   }
 
+  // Shown only when the cart is full (toggled by pdf-cart.js).
+  &__limit {
+    margin: .5em 0 0;
+    color: $red;
+    font-size: .9rem;
+  }
+
   // The selected count, emphasized with a gold underline.
   &__count {
     font-weight: bold;

--- a/app/javascript/app/cart/pdf-cart.js
+++ b/app/javascript/app/cart/pdf-cart.js
@@ -6,6 +6,9 @@ import cookie from '../util/cookie';
 const COOKIE_NAME = 'pdf_cart';
 // Days until the cart cookie expires (keeps a selection across short browsing sessions).
 const COOKIE_DAYS = 1;
+// Maximum number of listings allowed in the cart / a single PDF. Adds past this
+// are blocked in _onClick and surfaced via the banner's limit message in sync().
+const MAX_ITEMS = 50;
 
 // Read the selected location IDs (as strings) from the cookie.
 // @return [Array<String>] The selected location IDs, or an empty array.
@@ -54,6 +57,9 @@ function sync() {
 
     const preview = banner.querySelector('.cart-banner__preview');
     if (preview) { preview.disabled = ids.length === 0; }
+
+    const limit = banner.querySelector('.cart-banner__limit');
+    if (limit) { limit.hidden = ids.length < MAX_ITEMS; }
   });
 
   document.querySelectorAll('.add-to-cart').forEach((button) => {
@@ -88,6 +94,10 @@ function _onClick(e) {
 
   if (ids.indexOf(id) !== -1) {
     ids = ids.filter((existing) => existing !== id);
+  } else if (ids.length >= MAX_ITEMS) {
+    // Cart is full: leave the selection untouched and just re-announce the limit.
+    sync();
+    return;
   } else {
     ids.push(id);
   }

--- a/app/views/component/locations/_cart_banner.html.haml
+++ b/app/views/component/locations/_cart_banner.html.haml
@@ -9,6 +9,7 @@
       %p.cart-banner__status{ aria: { live: 'polite' } }
         %span.cart-banner__count= count
         %span.cart-banner__label{ data: { one: t('cart_banner.listings_selected', count: 1), other: t('cart_banner.listings_selected', count: 2) } }= t('cart_banner.listings_selected', count: count)
+      %p.cart-banner__limit{ role: 'alert', hidden: true }= t('cart_banner.limit_reached', count: 50)
     %div.cart-banner__actions
       %button.cart-banner__preview#cart-banner-preview{ type: 'button', disabled: count.zero? }
         %span= t('cart_banner.preview')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -492,6 +492,7 @@ en:
     listings_selected:
       one: 'listing selected'
       other: 'listings selected'
+    limit_reached: "You've reached the maximum of %{count} listings. Remove one to add another."
     preview: 'Preview'
     add_to_pdf: 'Add to PDF'
   cart_preview:


### PR DESCRIPTION
## Description
limits the amount of locations which can be added to the cart to 50 

## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-147](https://app.clickup.com/t/9006094761/BCHDCC-147)
