### PR TITLE
[BCHDCC-170] Add To Cart Tooltip

### DIFF
--- a/app/assets/stylesheets/components/_add_to_cart_button.scss
+++ b/app/assets/stylesheets/components/_add_to_cart_button.scss
@@ -20,6 +20,36 @@
     color: $green;
   }
 
+  &__tooltip {
+    z-index: 10000;
+    pointer-events: none;
+    font-family: $font_sans_serif;
+    font-size: $font_size_95;
+    font-weight: normal;
+    letter-spacing: normal;
+    line-height: 1.4;
+    text-transform: none;
+  }
+
+  &__tooltip-title,
+  &__tooltip-body,
+  &__tooltip-added {
+    display: block;
+  }
+
+  &__tooltip-title {
+    font-size: $font_size_100;
+    font-weight: bold;
+  }
+
+  &__tooltip-added {
+    display: none;
+  }
+
+  &:focus-visible .add-to-cart__tooltip {
+    visibility: visible;
+  }
+
   // Selected state: hide the "add" affordance, reveal the green check.
   &.is-selected {
     .add-to-cart__icon--add,
@@ -30,6 +60,21 @@
     .add-to-cart__icon--added {
       display: inline-block;
     }
+
+    .add-to-cart__tooltip-title,
+    .add-to-cart__tooltip-body {
+      display: none;
+    }
+
+    .add-to-cart__tooltip-added {
+      display: block;
+    }
+  }
+}
+
+@media screen and (max-width: 784px) {
+  .add-to-cart__tooltip {
+    display: none;
   }
 }
 
@@ -52,8 +97,33 @@
   }
 }
 
+// Links inside a result entry carry `z-index: 9998` (_base.scss), so lift the button
+// above them while its tooltip is showing or the panel is painted underneath them.
+.results-entry .add-to-cart--index:hover,
+.results-entry .add-to-cart--index:focus-visible {
+  z-index: 10000;
+}
+
+// Anchor the tooltip to the button's right edge so it stays inside the results list.
+.add-to-cart.add-to-cart--index .add-to-cart__tooltip {
+  left: auto;
+  right: 0;
+  margin-left: 0;
+  margin-top: 18px;
+
+  // Inset by the same amount as the badge tooltip's arrow (mirrored) so the point
+  // sits on the flat edge rather than hanging off the rounded corner.
+  &::after {
+    left: auto;
+    right: 18px;
+    margin-left: 0;
+  }
+}
+
 // Show page: an inline "Add to PDF" button next to the location title.
-.add-to-cart--detail {
+// Doubled class so `display` outranks `.tooltip`'s `inline-block` (_base.scss is
+// imported after components/*).
+.add-to-cart.add-to-cart--detail {
   display: inline-flex;
   align-items: center;
   // Align only this button to the top of the header (without affecting the featured
@@ -79,6 +149,18 @@
 
   .add-to-cart__icon--added {
     font-size: 1.6rem;
+  }
+
+  // Left-align under the plus icon, which sits at this variant's left edge.
+  .add-to-cart__tooltip {
+    left: 0;
+    margin-left: 0;
+    margin-top: 18px;
+
+    &::after {
+      left: 18px;
+      margin-left: 0;
+    }
   }
 }
 

--- a/app/views/component/locations/_add_to_cart_button.html.haml
+++ b/app/views/component/locations/_add_to_cart_button.html.haml
@@ -3,8 +3,13 @@
 -# Selection state is driven client-side by app/javascript/app/cart/pdf-cart.js.
 -# Locals: location (required); variant (:index or :detail, default :index).
 - variant = local_assigns.fetch(:variant, :index)
-%button.add-to-cart{ class: "add-to-cart--#{variant}", type: 'button', data: { location_id: location.id, location_name: location.name }, aria: { pressed: 'false', label: "Add #{location.name} to PDF" } }
+%button.add-to-cart.tooltip{ class: "add-to-cart--#{variant}", type: 'button', data: { location_id: location.id, location_name: location.name }, aria: { pressed: 'false', label: "Add #{location.name} to PDF" } }
   %i.add-to-cart__icon.add-to-cart__icon--add.fa.fa-plus{ aria: { hidden: 'true' } }
   - if variant == :detail
     %span.add-to-cart__label= t('cart_banner.add_to_pdf')
   %i.add-to-cart__icon.add-to-cart__icon--added.fa.fa-check{ aria: { hidden: 'true' } }
+  %span.tooltiptext.add-to-cart__tooltip{ aria: { hidden: 'true' } }
+    %i.fa.fa-info-circle
+    %span.add-to-cart__tooltip-title= t('cart_banner.tooltip.title')
+    %span.add-to-cart__tooltip-body= t('cart_banner.tooltip.body')
+    %span.add-to-cart__tooltip-added= t('cart_banner.tooltip.added')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -495,6 +495,12 @@ en:
     limit_reached: "You've reached the maximum of %{count} listings. Remove one to add another."
     preview: 'Preview'
     add_to_pdf: 'Add to PDF'
+    tooltip:
+      title: 'What does this button do?'
+      body: >
+        Adds this listing to your print cart. Once you've added everything you
+        need, print them all together as one PDF.
+      added: 'This listing has been added to your cart.'
   cart_preview:
     title: 'Preview your selected services'
     heading: 'Preview your selected services'


### PR DESCRIPTION
## Description
Adds a tooltip to the add to cart button. Visible everywhere the button appears (locations list and individual show pages). Matches the tooltip on the Charmcare Favorite badge. Has different text depending on if the location has been added to the cart or not. 

## Motivation and Context
[BCHDCC-170](https://app.clickup.com/t/9006094761/BCHDCC-170)

## Screenshots
<img width="459" height="440" alt="Screenshot 2026-08-12 at 4 59 23 PM" src="https://github.com/user-attachments/assets/c9e62ffd-4b2b-4350-bcd4-e5fe6b9dd0dc" />
<img width="448" height="503" alt="Screenshot 2026-08-12 at 4 59 37 PM" src="https://github.com/user-attachments/assets/f444190d-9d87-4dda-afb8-876a637dbf81" />
