### PR TITLE
[BCHDCC-171] Maintain filtered search results after reviewing cart

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -8,6 +8,7 @@ class CartController < ApplicationController
   # and load the matching locations, preserving the order they were added.
   def preview
     @locations = cart_locations
+    @back_to_results_params = back_to_results_params
   end
 
   # Streams the selected listings as a PDF (name, phone, link and address per
@@ -24,6 +25,19 @@ class CartController < ApplicationController
   end
 
   private
+
+  # The params the "Go back" link needs to return the user to the search results
+  # they came from, with their search and filter selections intact. The locations
+  # page hands them to us on the preview URL (see
+  # app/javascript/app/cart/pdf-cart.js), the same way a location detail page
+  # carries them for its own back link.
+  #
+  # `layout` guards against going back to the layout-less partial the results
+  # page renders for AJAX filtering, and `back_navigation` keeps the return trip
+  # from being recorded as a brand new search.
+  def back_to_results_params
+    request.query_parameters.merge('layout' => true, 'back_navigation' => true)
+  end
 
   # The selected locations, ordered as they were added to the cart.
   def cart_locations

--- a/app/javascript/app/cart/pdf-cart.js
+++ b/app/javascript/app/cart/pdf-cart.js
@@ -4,6 +4,8 @@
 import cookie from '../util/cookie';
 
 const COOKIE_NAME = 'pdf_cart';
+// Where the banner's "Preview" button sends the user.
+const PREVIEW_URL = '/cart/preview';
 // Days until the cart cookie expires (keeps a selection across short browsing sessions).
 const COOKIE_DAYS = 1;
 // Maximum number of listings allowed in the cart / a single PDF. Adds past this
@@ -114,13 +116,18 @@ let _bound = false;
 // clicked. The banner is server-rendered and never swapped out, so a direct
 // listener fits (no delegation needed); the dataset guard keeps a repeat init()
 // on the same DOM from binding twice.
+//
+// The current query string rides along so the preview page can build its "Go
+// back" link out of it, returning the user to the search and filters they left
+// (see CartController#preview). This mirrors how a location detail page carries
+// the results-page params forward for its own back link.
 function _bindPreview() {
   document.querySelectorAll('.cart-banner__preview').forEach((button) => {
     if (button.dataset.previewBound) { return; }
     button.dataset.previewBound = 'true';
 
     button.addEventListener('click', () => {
-      if (!button.disabled) { window.location.href = '/cart/preview'; }
+      if (!button.disabled) { window.location.href = PREVIEW_URL + window.location.search; }
     });
   });
 }

--- a/app/views/cart/preview.html.haml
+++ b/app/views/cart/preview.html.haml
@@ -1,10 +1,10 @@
 - title t('cart_preview.title')
 
 - content_for :breadcrumbs do
-  = link_to t('cart_preview.breadcrumb'), locations_path
+  = link_to t('cart_preview.breadcrumb'), locations_path(@back_to_results_params)
 
 %div.cart-preview
-  = link_to locations_path, class: 'cart-preview__back' do
+  = link_to locations_path(@back_to_results_params), class: 'cart-preview__back' do
     %i.fa.fa-chevron-left{ aria: { hidden: 'true' } }
     %span= t('cart_preview.go_back')
 

--- a/spec/requests/cart_preview_spec.rb
+++ b/spec/requests/cart_preview_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe 'GET /cart/preview' do
+  context 'when the locations page passed its search and filter params along' do
+    # NB: spec/support/default_headers.rb overrides `get` to take its params
+    # positionally, so they can't be passed as `params:` here.
+    before do
+      get '/cart/preview',
+          keyword: 'food',
+          main_category: 'Food',
+          categories: %w[Groceries Meals],
+          distance: '5',
+          address: '21201'
+    end
+
+    it 'returns a 200 HTTP status' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'points the "Go back" link at the same search' do
+      href = back_link_href
+
+      expect(href).to start_with('/locations?')
+      expect(query_params_of(href)).to include(
+        'keyword' => 'food',
+        'main_category' => 'Food',
+        'categories' => %w[Groceries Meals],
+        'distance' => '5',
+        'address' => '21201'
+      )
+    end
+
+    it 'marks the return trip so it is not counted as a new search' do
+      expect(query_params_of(back_link_href)).to include('back_navigation' => 'true')
+    end
+
+    it 'asks for the full results page rather than the AJAX partial' do
+      expect(query_params_of(back_link_href)).to include('layout' => 'true')
+    end
+
+    it 'points the breadcrumb at the same search' do
+      breadcrumb = page_body.css('#breadcrumb a').last
+
+      expect(breadcrumb.text).to eq('Community Resources')
+      expect(breadcrumb[:href]).to eq(back_link_href)
+    end
+  end
+
+  context 'when there were no search params to preserve' do
+    before { get '/cart/preview' }
+
+    it 'still links back to the results page' do
+      expect(back_link_href).to start_with('/locations')
+    end
+  end
+
+  def page_body
+    Nokogiri::HTML(response.body)
+  end
+
+  def back_link_href
+    page_body.at_css('.cart-preview__back')[:href]
+  end
+
+  def query_params_of(href)
+    Rack::Utils.parse_nested_query(URI.parse(href).query)
+  end
+end


### PR DESCRIPTION
## Description
Maintains location search and filter selections upon navigation to the cart preview page by storing them in the url, the same approach taken by individual location pages. 


## Motivation and Context
<!-- ClickUp ticket IDs are autolinked. So, you only need to list the ticket ID(s) related to this PR -->
[BCHDCC-171](https://app.clickup.com/t/9006094761/BCHDCC-171)


## Tests to Run
added new `spec/requests/cart_preview_spec.rb` file for testing the preserved filter behavior